### PR TITLE
logcat hang bugfix

### DIFF
--- a/src/main/java/org/acra/collector/LogCatCollector.java
+++ b/src/main/java/org/acra/collector/LogCatCollector.java
@@ -23,6 +23,7 @@ import org.acra.util.BoundedLinkedList;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -99,6 +100,20 @@ class LogCatCollector {
             final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()), ACRAConstants.DEFAULT_BUFFER_SIZE_IN_BYTES);
 
             Log.d(LOG_TAG, "Retrieving logcat output...");
+
+            // Dump stderr to null
+            new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        InputStream stderr = process.getErrorStream();
+                        byte[] dummy = new byte[ACRAConstants.DEFAULT_BUFFER_SIZE_IN_BYTES];
+                        while (stderr.read(dummy) >= 0)
+                            ;
+                    } catch (IOException e) {
+                    }
+                }
+            }).start();
+
             while (true) {
                 final String line = bufferedReader.readLine();
                 if (line == null) {


### PR DESCRIPTION
On some devices I've been using (Sony Xperia is one), including the LOGCAT field occasionally hangs when fetching the log. This seems to be due to logcat trying to write to stderr and blocking - this fix reads the stderr stream to a dummy buffer to keep things moving.
