### PR TITLE
Switching back to a SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
 	<groupId>ch.acra</groupId>
 	<artifactId>acra</artifactId>
-	<version>4.5.0-alpha-1</version>
+	<version>4.5.0-alpha-2-SNAPSHOT</version>
 
 	<name>Application Crash Report for Android</name>
 


### PR DESCRIPTION
Kevin, I inadvertently changed the POM to be 4.5.0-alpha-1 when it should have remained as a SNAPSHOT. We need to get back to a snapshot so we don't end up with differing versions of alpha-1 in existence.
