### PR TITLE
Fixing BasicSetup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ What is ACRA ?
 
 ACRA is a library enabling Android Application to automatically post their crash reports to a GoogleDoc form. It is targetted to android applications developers to help them get data from their applications when they crash or behave erroneously.
 
-See [BasicSetup](acra/wiki/BasicSetup) for a step-by-step installation and usage guide.
+See [BasicSetup](http://github.com/ACRA/acra/wiki/BasicSetup) for a step-by-step installation and usage guide.
 
 A crash reporting feature for android apps is native since Android 2.2 (FroYo) but only available through the official Android Market (and with limited data). ACRA is a great help for Android developers :
 


### PR DESCRIPTION
The link points to BasicSetup link directs to https://github.com/ACRA/acra/blob/master/acra/wiki/BasicSetup (Page not found) instead of https://github.com/ACRA/acra/wiki/BasicSetup. Furthermore, URL in repository files should be absolute (not everybody reads it through GitHub)
