### PR TITLE
Added a new method ErrorReporter#addOnExceptionHandledCommand

### DIFF
--- a/src/main/java/org/acra/ExceptionHandlerInitializer.java
+++ b/src/main/java/org/acra/ExceptionHandlerInitializer.java
@@ -1,0 +1,19 @@
+package org.acra;
+
+/**
+ * The interface can be used with
+ * {@link ErrorReporter#setExceptionHandlerInitializer(ExceptionHandlerInitializer)}
+ * to add an additional initialization of the {@link ErrorReporter} before
+ * exception is handled.
+ * 
+ * @see {@link ErrorReporter#setExceptionHandlerInitializer(ExceptionHandlerInitializer)}
+ * 
+ */
+public interface ExceptionHandlerInitializer {
+    /**
+     * Called before {@link ErrorReporter} handles the Exception.
+     * 
+     * @param reporter
+     */
+    void initializeExceptionHandler(ErrorReporter reporter);
+}


### PR DESCRIPTION
Sometimes it could be nice to put custom data also to the uncaught exception. Of course, we can add an uncaught exception handler to all threads after initalizing ACRA, but this might not be very straightforward.

Use this method to add commands to be executed before the ErrorReporter
handles the throwable. This can be used to put custom data.

This allows to add custom data to uncaught exceptions and to be sure that all silent exceptions contain the same data set.

Example usage (in onCreate, after initing ACRA)

```
    ACRA.getErrorReporter().addOnExceptionHandledCommand(new Runnable() {
        @Override
        public void run() {
            ACRA.getErrorReporter().putCustomData("STARTUP_LOG",
                    StartupLogWriter.getInstance().getMessagesAsString());
        }
    });
```

I hope this can be useful.
