### PR TITLE
Introduced manual non-annotation based init methods.

### DIFF
--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -114,19 +114,43 @@ public class ACRA {
      *             if it is called more than once.
      */
     public static void init(Application app) {
+        ReportsCrashes reportsCrashes = mApplication.getClass().getAnnotation(ReportsCrashes.class);
+        if (reportsCrashes == null) {
+            log.e(LOG_TAG,
+                    "ACRA#init called but no ReportsCrashes annotation on Application " + app.getPackageName());
+            return;
+        }
+        init(app, new ACRAConfiguration(reportsCrashes));
+    }
+
+    /**
+     * <p>
+     * Initialize ACRA for a given Application. The call to this method should
+     * be placed as soon as possible in the {@link Application#onCreate()}
+     * method.
+     * </p>
+     *
+     * @param app
+     *            Your Application class.
+     * @param reportsCrashes
+     *            ACRAConfiguration to manually set up ACRA configuration.
+     * @throws IllegalStateException
+     *             if it is called more than once.
+     */
+    public static void init(Application app, ACRAConfiguration config){
 
         if (mApplication != null) {
             log.w(LOG_TAG, "ACRA#init called more than once. Won't do anything more.");
             return;
         }
-
         mApplication = app;
-        mReportsCrashes = mApplication.getClass().getAnnotation(ReportsCrashes.class);
-        if (mReportsCrashes == null) {
+        
+        if (config == null) {
             log.e(LOG_TAG,
-                    "ACRA#init called but no ReportsCrashes annotation on Application " + mApplication.getPackageName());
+                    "ACRA#init called but no ACRAConfiguration provided");
             return;
         }
+        setConfig(config);
 
         final SharedPreferences prefs = getACRASharedPreferences();
 

--- a/src/main/java/org/acra/ACRAConfiguration.java
+++ b/src/main/java/org/acra/ACRAConfiguration.java
@@ -111,8 +111,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param headers
      *            A map associating HTTP header names to their values.
      */
-    public void setHttpHeaders(Map<String, String> headers) {
+    public ACRAConfiguration setHttpHeaders(Map<String, String> headers) {
         this.mHttpHeaders = headers;
+        return this;
     }
 
     /**
@@ -130,63 +131,71 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param additionalDropboxTags
      *            the additionalDropboxTags to set
      */
-    public void setAdditionalDropboxTags(String[] additionalDropboxTags) {
+    public ACRAConfiguration setAdditionalDropboxTags(String[] additionalDropboxTags) {
         this.mAdditionalDropboxTags = additionalDropboxTags;
+        return this;
     }
 
     /**
      * @param additionalSharedPreferences
      *            the additionalSharedPreferences to set
      */
-    public void setAdditionalSharedPreferences(String[] additionalSharedPreferences) {
+    public ACRAConfiguration setAdditionalSharedPreferences(String[] additionalSharedPreferences) {
         this.mAdditionalSharedPreferences = additionalSharedPreferences;
+        return this;
     }
 
     /**
      * @param connectionTimeout
      *            the connectionTimeout to set
      */
-    public void setConnectionTimeout(Integer connectionTimeout) {
+    public ACRAConfiguration setConnectionTimeout(Integer connectionTimeout) {
         this.mConnectionTimeout = connectionTimeout;
+        return this;
     }
 
     /**
      * @param customReportContent
      *            the customReportContent to set
      */
-    public void setCustomReportContent(ReportField[] customReportContent) {
+    public ACRAConfiguration setCustomReportContent(ReportField[] customReportContent) {
         this.mCustomReportContent = customReportContent;
+        return this;
     }
 
     /**
      * @param deleteUnapprovedReportsOnApplicationStart
      *            the deleteUnapprovedReportsOnApplicationStart to set
      */
-    public void setDeleteUnapprovedReportsOnApplicationStart(Boolean deleteUnapprovedReportsOnApplicationStart) {
+    public ACRAConfiguration setDeleteUnapprovedReportsOnApplicationStart(Boolean deleteUnapprovedReportsOnApplicationStart) {
         this.mDeleteUnapprovedReportsOnApplicationStart = deleteUnapprovedReportsOnApplicationStart;
+        return this;
     }
 
     /**
      * @param deleteOldUnsetReportsOnApplicationStart
      */
-    public void setDeleteOldUnsentReportsOnApplicationStart(Boolean deleteOldUnsetReportsOnApplicationStart) {
+    public ACRAConfiguration setDeleteOldUnsentReportsOnApplicationStart(Boolean deleteOldUnsetReportsOnApplicationStart) {
         this.mDeleteOldUnsentReportsOnApplicationStart = deleteOldUnsetReportsOnApplicationStart;
+        return this;
     }
 
     /**
      * @param dropboxCollectionMinutes
      *            the dropboxCollectionMinutes to set
      */
-    public void setDropboxCollectionMinutes(Integer dropboxCollectionMinutes) {
+    public ACRAConfiguration setDropboxCollectionMinutes(Integer dropboxCollectionMinutes) {
         this.mDropboxCollectionMinutes = dropboxCollectionMinutes;
+        return this;
     }
 
     /**
      * @param forceCloseDialogAfterToast
      *            the forceCloseDialogAfterToast to set
      */
-    public void setForceCloseDialogAfterToast(Boolean forceCloseDialogAfterToast) {
+    public ACRAConfiguration setForceCloseDialogAfterToast(Boolean forceCloseDialogAfterToast) {
         this.mForceCloseDialogAfterToast = forceCloseDialogAfterToast;
+        return this;
     }
 
     /**
@@ -198,8 +207,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param formKey
      *            the formKey to set
      */
-    public void setFormKey(String formKey) {
+    public ACRAConfiguration setFormKey(String formKey) {
         this.mFormKey = formKey;
+        return this;
     }
 
     /**
@@ -211,40 +221,45 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param formUri
      *            the formUri to set
      */
-    public void setFormUri(String formUri) {
+    public ACRAConfiguration setFormUri(String formUri) {
         this.mFormUri = formUri;
+        return this;
     }
 
     /**
      * @param formUriBasicAuthLogin
      *            the formUriBasicAuthLogin to set
      */
-    public void setFormUriBasicAuthLogin(String formUriBasicAuthLogin) {
+    public ACRAConfiguration setFormUriBasicAuthLogin(String formUriBasicAuthLogin) {
         this.mFormUriBasicAuthLogin = formUriBasicAuthLogin;
+        return this;
     }
 
     /**
      * @param formUriBasicAuthPassword
      *            the formUriBasicAuthPassword to set
      */
-    public void setFormUriBasicAuthPassword(String formUriBasicAuthPassword) {
+    public ACRAConfiguration setFormUriBasicAuthPassword(String formUriBasicAuthPassword) {
         this.mFormUriBasicAuthPassword = formUriBasicAuthPassword;
+        return this;
     }
 
     /**
      * @param includeDropboxSystemTags
      *            the includeDropboxSystemTags to set
      */
-    public void setIncludeDropboxSystemTags(Boolean includeDropboxSystemTags) {
+    public ACRAConfiguration setIncludeDropboxSystemTags(Boolean includeDropboxSystemTags) {
         this.mIncludeDropboxSystemTags = includeDropboxSystemTags;
+        return this;
     }
 
     /**
      * @param logcatArguments
      *            the logcatArguments to set
      */
-    public void setLogcatArguments(String[] logcatArguments) {
+    public ACRAConfiguration setLogcatArguments(String[] logcatArguments) {
         this.mLogcatArguments = logcatArguments;
+        return this;
     }
 
     /**
@@ -256,16 +271,18 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param mailTo
      *            the mailTo to set
      */
-    public void setMailTo(String mailTo) {
+    public ACRAConfiguration setMailTo(String mailTo) {
         this.mMailTo = mailTo;
+        return this;
     }
 
     /**
      * @param maxNumberOfRequestRetries
      *            the maxNumberOfRequestRetries to set
      */
-    public void setMaxNumberOfRequestRetries(Integer maxNumberOfRequestRetries) {
+    public ACRAConfiguration setMaxNumberOfRequestRetries(Integer maxNumberOfRequestRetries) {
         this.mMaxNumberOfRequestRetries = maxNumberOfRequestRetries;
+        return this;
     }
 
     /**
@@ -277,9 +294,10 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @throws ACRAConfigurationException
      *             if a configuration item is missing for this mode.
      */
-    public void setMode(ReportingInteractionMode mode) throws ACRAConfigurationException {
+    public ACRAConfiguration setMode(ReportingInteractionMode mode) throws ACRAConfigurationException {
         this.mMode = mode;
         ACRA.checkCrashResources();
+        return this;
     }
 
     /**
@@ -291,8 +309,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            The resource id, see
      *            {@link ReportsCrashes#resDialogCommentPrompt()}
      */
-    public void setResDialogCommentPrompt(int resId) {
+    public ACRAConfiguration setResDialogCommentPrompt(int resId) {
         mResDialogCommentPrompt = resId;
+        return this;
     }
 
     /**
@@ -304,8 +323,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            The resource id, see
      *            {@link ReportsCrashes#resDialogEmailPrompt()}
      */
-    public void setResDialogEmailPrompt(int resId) {
+    public ACRAConfiguration setResDialogEmailPrompt(int resId) {
         mResDialogEmailPrompt = resId;
+        return this;
     }
 
     /**
@@ -316,8 +336,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resDialogIcon()}
      */
-    public void setResDialogIcon(int resId) {
+    public ACRAConfiguration setResDialogIcon(int resId) {
         mResDialogIcon = resId;
+        return this;
     }
 
     /**
@@ -328,8 +349,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resDialogOkToast()}
      */
-    public void setResDialogOkToast(int resId) {
+    public ACRAConfiguration setResDialogOkToast(int resId) {
         mResDialogOkToast = resId;
+        return this;
     }
 
     /**
@@ -340,8 +362,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resDialogText()}
      */
-    public void setResDialogText(int resId) {
+    public ACRAConfiguration setResDialogText(int resId) {
         mResDialogText = resId;
+        return this;
     }
 
     /**
@@ -352,8 +375,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resDialogTitle()}
      */
-    public void setResDialogTitle(int resId) {
+    public ACRAConfiguration setResDialogTitle(int resId) {
         mResDialogTitle = resId;
+        return this;
     }
 
     /**
@@ -364,8 +388,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resNotifIcon()}
      */
-    public void setResNotifIcon(int resId) {
+    public ACRAConfiguration setResNotifIcon(int resId) {
         mResNotifIcon = resId;
+        return this;
     }
 
     /**
@@ -376,8 +401,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resNotifText()}
      */
-    public void setResNotifText(int resId) {
+    public ACRAConfiguration setResNotifText(int resId) {
         mResNotifText = resId;
+        return this;
     }
 
     /**
@@ -389,8 +415,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            The resource id, see
      *            {@link ReportsCrashes#resNotifTickerText()}
      */
-    public void setResNotifTickerText(int resId) {
+    public ACRAConfiguration setResNotifTickerText(int resId) {
         mResNotifTickerText = resId;
+        return this;
     }
 
     /**
@@ -401,8 +428,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resNotifTitle()}
      */
-    public void setResNotifTitle(int resId) {
+    public ACRAConfiguration setResNotifTitle(int resId) {
         mResNotifTitle = resId;
+        return this;
     }
 
     /**
@@ -413,32 +441,36 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resToastText()}
      */
-    public void setResToastText(int resId) {
+    public ACRAConfiguration setResToastText(int resId) {
         mResToastText = resId;
+        return this;
     }
 
     /**
      * @param sharedPreferenceMode
      *            the sharedPreferenceMode to set
      */
-    public void setSharedPreferenceMode(Integer sharedPreferenceMode) {
+    public ACRAConfiguration setSharedPreferenceMode(Integer sharedPreferenceMode) {
         this.mSharedPreferenceMode = sharedPreferenceMode;
+        return this;
     }
 
     /**
      * @param sharedPreferenceName
      *            the sharedPreferenceName to set
      */
-    public void setSharedPreferenceName(String sharedPreferenceName) {
+    public ACRAConfiguration setSharedPreferenceName(String sharedPreferenceName) {
         this.mSharedPreferenceName = sharedPreferenceName;
+        return this;
     }
 
     /**
      * @param socketTimeout
      *            the socketTimeout to set
      */
-    public void setSocketTimeout(Integer socketTimeout) {
+    public ACRAConfiguration setSocketTimeout(Integer socketTimeout) {
         this.mSocketTimeout = socketTimeout;
+        return this;
     }
 
     /**
@@ -447,8 +479,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            true if you want to collect only logcat lines related to your
      *            application process.
      */
-    public void setLogcatFilterByPid(Boolean filterByPid) {
+    public ACRAConfiguration setLogcatFilterByPid(Boolean filterByPid) {
         mLogcatFilterByPid = filterByPid;
+        return this;
     }
 
     /**
@@ -457,8 +490,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            false if you want to disable sending reports in development
      *            mode. Reports will be sent only on signed applications.
      */
-    public void setSendReportsInDevMode(Boolean sendReportsInDevMode) {
+    public ACRAConfiguration setSendReportsInDevMode(Boolean sendReportsInDevMode) {
         mSendReportsInDevMode = sendReportsInDevMode;
+        return this;
     }
 
     /**
@@ -468,8 +502,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            SharedPreferences keys that should be excluded from the data
      *            collection.
      */
-    public void setExcludeMatchingSharedPreferencesKeys(String[] excludeMatchingSharedPreferencesKeys) {
+    public ACRAConfiguration setExcludeMatchingSharedPreferencesKeys(String[] excludeMatchingSharedPreferencesKeys) {
         mExcludeMatchingSharedPreferencesKeys = excludeMatchingSharedPreferencesKeys;
+        return this;
     }
 
     /**
@@ -479,8 +514,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            Settings.System, Settings.Secure and Settings.Global keys that
      *            should be excluded from the data collection.
      */
-    public void setExcludeMatchingSettingsKeys(String[] excludeMatchingSettingsKeys) {
+    public ACRAConfiguration setExcludeMatchingSettingsKeys(String[] excludeMatchingSettingsKeys) {
         mExcludeMatchingSettingsKeys = excludeMatchingSettingsKeys;
+        return this;
     }
 
     /**
@@ -489,8 +525,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            The path and file name of your application log file, to be
      *            used with {@link ReportField#APPLICATION_LOG}.
      */
-    public void setApplicationLogFile(String applicationLogFile) {
+    public ACRAConfiguration setApplicationLogFile(String applicationLogFile) {
         mApplicationLogFile = applicationLogFile;
+        return this;
     }
 
     /**
@@ -500,8 +537,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            to be used with {@link ReportField#APPLICATION_LOG} and
      *            {@link ReportsCrashes#applicationLogFile()}.
      */
-    public void setApplicationLogFileLines(int applicationLogFileLines) {
+    public ACRAConfiguration setApplicationLogFileLines(int applicationLogFileLines) {
         mApplicationLogFileLines = applicationLogFileLines;
+        return this;
     }
 
     /**
@@ -510,8 +548,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            Set this to true if you need to send reports to a server over
      *            SSL using a self-signed certificate.
      */
-    public void setDisableSSLCertValidation(boolean disableSSLCertValidation) {
+    public ACRAConfiguration setDisableSSLCertValidation(boolean disableSSLCertValidation) {
         mDisableSSLCertValidation = disableSSLCertValidation;
+        return this;
     }
 
     /**
@@ -519,8 +558,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param httpMethod
      *            The method to be used to send data to the server.
      */
-    public void setHttpMethod(Method httpMethod) {
+    public ACRAConfiguration setHttpMethod(Method httpMethod) {
         mHttpMethod = httpMethod;
+        return this;
     }
 
     /**
@@ -529,8 +569,9 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            The type of content encoding to be used to send data to the
      *            server.
      */
-    public void setReportType(Type type) {
+    public ACRAConfiguration setReportType(Type type) {
         mReportType = type;
+        return this;
     }
 
     /**
@@ -539,6 +580,13 @@ public class ACRAConfiguration implements ReportsCrashes {
      */
     public ACRAConfiguration(ReportsCrashes defaults) {
         mReportsCrashes = defaults;
+    }
+
+    /**
+     * Empty constructor which sets no defaults.
+     */
+    public ACRAConfiguration(){
+        this(null);
     }
 
     @Override


### PR DESCRIPTION
Added the additional init methods as discussed.  I felt a configuration builder helped here as instantiating the ACRAConfiguration was a bit messy.  Here's the resulting manual setup:

```
ACRA.init(application, ACRAConfigurationBuilder.builder().setFormUri("uri"));
```

or if you static import ACRAConfigurationBuilder:

```
ACRA.init(application, builder().setFormUri("uri"));
```

I also avoided adding the formKey as it is mentioned as depreciated.  BTW, could you in the `ReportsCrashes` set the `String formKey() default "";`, `@Depreciate` it, then remove it in a later release?
