### PR TITLE
Added setBasicAuth method to override global credential

### DIFF
--- a/src/main/java/org/acra/sender/HttpSender.java
+++ b/src/main/java/org/acra/sender/HttpSender.java
@@ -112,6 +112,8 @@ public class HttpSender implements ReportSender {
     private final Map<ReportField, String> mMapping;
     private final Method mMethod;
     private final Type mType;
+    private String mUsername;
+    private String mPassword;
 
     /**
      * <p>
@@ -143,6 +145,8 @@ public class HttpSender implements ReportSender {
         mFormUri = null;
         mMapping = mapping;
         mType = type;
+        mUsername = null;
+        mPassword = null;
     }
 
     /**
@@ -175,7 +179,25 @@ public class HttpSender implements ReportSender {
         mFormUri = Uri.parse(formUri);
         mMapping = mapping;
         mType = type;
+        mUsername = null;
+        mPassword = null;        
     }
+    
+    /**
+     * <p>
+     * Set credentials for this HttpSender that override (if present) the ones
+     * set globally.
+     * </p>
+     * 
+     * @param username
+     *            The username to set for HTTP Basic Auth.
+     * @param password
+     *            The password to set for HTTP Basic Auth.
+     */
+    public void setBasicAuth(String username, String password) {
+        mUsername = username;
+        mPassword = password;
+    }    
 
     @Override
     public void send(CrashReportData report) throws ReportSenderException {
@@ -184,9 +206,9 @@ public class HttpSender implements ReportSender {
             URL reportUrl = mFormUri == null ? new URL(ACRA.getConfig().formUri()) : new URL(mFormUri.toString());
             Log.d(LOG_TAG, "Connect to " + reportUrl.toString());
 
-            final String login = ACRAConfiguration.isNull(ACRA.getConfig().formUriBasicAuthLogin()) ? null : ACRA
+            final String login = mUsername != null ? mUsername : ACRAConfiguration.isNull(ACRA.getConfig().formUriBasicAuthLogin()) ? null : ACRA
                     .getConfig().formUriBasicAuthLogin();
-            final String password = ACRAConfiguration.isNull(ACRA.getConfig().formUriBasicAuthPassword()) ? null : ACRA
+            final String password = mPassword != null ? mPassword : ACRAConfiguration.isNull(ACRA.getConfig().formUriBasicAuthPassword()) ? null : ACRA
                     .getConfig().formUriBasicAuthPassword();
 
             final HttpRequest request = new HttpRequest();


### PR DESCRIPTION
Added the setBasicAuth method to the HttpSender to allow users to set multiple HttpSender with different auth settings.
