### PR TITLE
allow pinning / giving specific server certificate to check for

### DIFF
--- a/src/main/java/org/acra/ACRAConfiguration.java
+++ b/src/main/java/org/acra/ACRAConfiguration.java
@@ -35,9 +35,11 @@ import static org.acra.ACRAConstants.DEFAULT_SEND_REPORTS_IN_DEV_MODE;
 import static org.acra.ACRAConstants.DEFAULT_SHARED_PREFERENCES_MODE;
 import static org.acra.ACRAConstants.DEFAULT_SOCKET_TIMEOUT;
 import static org.acra.ACRAConstants.DEFAULT_STRING_VALUE;
+import static org.acra.ACRAConstants.DEFAULT_TRUST_SSL_CERT;
 import static org.acra.ACRAConstants.NULL_VALUE;
 
 import java.lang.annotation.Annotation;
+import java.security.cert.Certificate;
 import java.util.Map;
 
 import org.acra.annotation.ReportsCrashes;
@@ -103,6 +105,9 @@ public class ACRAConfiguration implements ReportsCrashes {
     private Method mHttpMethod = null;
     private Type mReportType = null;
     private Map<String, String> mHttpHeaders;
+
+    private String mTrustSSLCertName = null;
+    private Certificate mTrustSSLCert = DEFAULT_TRUST_SSL_CERT;
 
     /**
      * Set custom HTTP headers to be sent by the provided {@link HttpSender}.
@@ -512,6 +517,18 @@ public class ACRAConfiguration implements ReportsCrashes {
      */
     public void setDisableSSLCertValidation(boolean disableSSLCertValidation) {
         mDisableSSLCertValidation = disableSSLCertValidation;
+    }
+
+    /**
+     *
+     * @param trustSSLCertName
+     */
+    public void setTrustSSLCertName(String trustSSLCertName) {
+        mTrustSSLCertName = trustSSLCertName;
+    }
+
+    public void setTrustSSLCert(Certificate trustSSLCert) {
+        mTrustSSLCert = trustSSLCert;
     }
 
     /**
@@ -1059,6 +1076,23 @@ public class ACRAConfiguration implements ReportsCrashes {
         }
 
         return DEFAULT_DISABLE_SSL_CERT_VALIDATION;
+    }
+
+    @Override
+    public String trustSSLCertName() {
+        if (mTrustSSLCertName != null) {
+            return mTrustSSLCertName;
+        }
+
+        if (mReportsCrashes != null) {
+            return mReportsCrashes.trustSSLCertName();
+        }
+
+        return DEFAULT_STRING_VALUE;
+    }
+
+    public Certificate trustSSLCert() {
+        return mTrustSSLCert;
     }
 
     @Override

--- a/src/main/java/org/acra/ACRAConstants.java
+++ b/src/main/java/org/acra/ACRAConstants.java
@@ -46,6 +46,9 @@ import static org.acra.ReportField.USER_APP_START_DATE;
 import static org.acra.ReportField.USER_COMMENT;
 import static org.acra.ReportField.USER_CRASH_DATE;
 import static org.acra.ReportField.USER_EMAIL;
+
+import java.security.cert.Certificate;
+
 import android.content.Context;
 
 /**
@@ -143,6 +146,8 @@ public final class ACRAConstants {
     public static final String DEFAULT_GOOGLE_FORM_URL_FORMAT = "https://docs.google.com/spreadsheet/formResponse?formkey=%s&ifq";
 
     public static final boolean DEFAULT_DISABLE_SSL_CERT_VALIDATION = false;
+
+    public static final Certificate DEFAULT_TRUST_SSL_CERT = null;
 
     /**
      * Default list of {@link ReportField}s to be sent in email reports. You can

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -545,4 +545,14 @@ public @interface ReportsCrashes {
     Method httpMethod() default Method.POST;
 
     Type reportType() default Type.FORM;
+
+    /**
+     * <p>
+     * Set this to the name of the asset that contains a PEM encoded X509 certificate that validates
+     * your server
+     * </p>
+     *
+     * @return the filename of the trusted certificate
+     */
+    String trustSSLCertName() default ACRAConstants.DEFAULT_STRING_VALUE;
 }


### PR DESCRIPTION
This will apps allow to provide a custom trust anchor. This can be interesting for two cases:
1. self signed certificates or untrusted CAs (such as CACert.org)
2. pinning
