### PR TITLE
Use ACTION_SENDTO in EmailIntentSender

### DIFF
--- a/src/main/java/org/acra/sender/EmailIntentSender.java
+++ b/src/main/java/org/acra/sender/EmailIntentSender.java
@@ -50,7 +50,6 @@ public class EmailIntentSender implements ReportSender {
         emailIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         emailIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, subject);
         emailIntent.putExtra(android.content.Intent.EXTRA_TEXT, body);
-        emailIntent.putExtra(android.content.Intent.EXTRA_EMAIL, new String[] { ACRA.getConfig().mailTo() });
         mContext.startActivity(emailIntent);
     }
 


### PR DESCRIPTION
The use of `ACTION_SEND` in `EmailIntentSender` causes the `Intent` to resolve to not just email apps, but also _Skype_, _Google Drive_ or _Bluetooth_, to name just a few. While this might be desirable in certain cases, the name `EmailIntentSender` clearly implies that the report is to be sent via email only.

Using `ACTION_SENDTO` in conjunction with a `mailto:` URI as the `Intent`'s data makes it resolve to email apps only (_Email_ and _Gmail_ in my case).

Tested on: Android 4.4.2 Stock (Nexus 4) and Android 2.3 Stock (Emulator)
