### PR TITLE
Add the ability to customize the text of positive and negative buttons of CrashReportDialog

### DIFF
--- a/src/main/java/org/acra/ACRAConfiguration.java
+++ b/src/main/java/org/acra/ACRAConfiguration.java
@@ -76,6 +76,8 @@ public class ACRAConfiguration implements ReportsCrashes {
     private ReportingInteractionMode mMode = null;
     private ReportsCrashes mReportsCrashes = null;
 
+    private Integer mResDialogPositiveButtonText = null;
+    private Integer mResDialogNegativeButtonText = null;
     private Integer mResDialogCommentPrompt = null;
     private Integer mResDialogEmailPrompt = null;
     private Integer mResDialogIcon = null;
@@ -299,6 +301,16 @@ public class ACRAConfiguration implements ReportsCrashes {
     public ACRAConfiguration setMode(ReportingInteractionMode mode) throws ACRAConfigurationException {
         this.mMode = mode;
         ACRA.checkCrashResources();
+        return this;
+    }
+
+    public ACRAConfiguration setResDialogPositiveButtonText(int resId) {
+        mResDialogPositiveButtonText = resId;
+        return this;
+    }
+
+    public ACRAConfiguration setResDialogNegativeButtonText(int resId) {
+        mResDialogNegativeButtonText = resId;
         return this;
     }
 
@@ -828,6 +840,32 @@ public class ACRAConfiguration implements ReportsCrashes {
         }
 
         return ReportingInteractionMode.SILENT;
+    }
+
+    @Override
+    public int resDialogPositiveButtonText() {
+        if (mResDialogPositiveButtonText != null) {
+            return mResDialogPositiveButtonText;
+        }
+
+        if (mReportsCrashes != null) {
+            return mReportsCrashes.resDialogPositiveButtonText();
+        }
+
+        return DEFAULT_RES_VALUE;
+    }
+
+    @Override
+    public int resDialogNegativeButtonText() {
+        if (mResDialogNegativeButtonText != null) {
+            return mResDialogNegativeButtonText;
+        }
+
+        if (mReportsCrashes != null) {
+            return mReportsCrashes.resDialogNegativeButtonText();
+        }
+
+        return DEFAULT_RES_VALUE;
     }
 
     @Override

--- a/src/main/java/org/acra/ACRAConstants.java
+++ b/src/main/java/org/acra/ACRAConstants.java
@@ -95,6 +95,10 @@ public final class ACRAConstants {
 
     public static final int DEFAULT_DIALOG_ICON = android.R.drawable.ic_dialog_alert;
 
+    public static final int DEFAULT_DIALOG_POSITIVE_BUTTON_TEXT = android.R.string.ok;
+
+    public static final int DEFAULT_DIALOG_NEGATIVE_BUTTON_TEXT = android.R.string.cancel;
+
     public static final int DEFAULT_RES_VALUE = 0;
 
     public static final String DEFAULT_STRING_VALUE = "";

--- a/src/main/java/org/acra/CrashReportDialog.java
+++ b/src/main/java/org/acra/CrashReportDialog.java
@@ -67,8 +67,8 @@ public class CrashReportDialog extends Activity implements DialogInterface.OnCli
             dialogBuilder.setIcon(resourceId);
         }
         dialogBuilder.setView(buildCustomView(savedInstanceState));
-        dialogBuilder.setPositiveButton(android.R.string.ok, CrashReportDialog.this);
-        dialogBuilder.setNegativeButton(android.R.string.cancel, CrashReportDialog.this);
+        dialogBuilder.setPositiveButton(getText(ACRA.getConfig().resDialogPositiveButtonText()), CrashReportDialog.this);
+        dialogBuilder.setNegativeButton(getText(ACRA.getConfig().resDialogNegativeButtonText()), CrashReportDialog.this);
         cancelNotification();
         mDialog = dialogBuilder.create();
         mDialog.setCanceledOnTouchOutside(false);

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -88,6 +88,18 @@ public @interface ReportsCrashes {
     ReportingInteractionMode mode() default ReportingInteractionMode.SILENT;
 
     /**
+     * @return Resource id for the label of positive button in the crash dialog.
+     *         If not provided, defaults to 'OK'.
+     */
+    int resDialogPositiveButtonText() default ACRAConstants.DEFAULT_DIALOG_POSITIVE_BUTTON_TEXT;
+
+    /**
+     * @return Resource id for the label of negative button in the crash dialog.
+     *         If not provided, defaults to 'cancel'.
+     */
+    int resDialogNegativeButtonText() default ACRAConstants.DEFAULT_DIALOG_NEGATIVE_BUTTON_TEXT;
+
+    /**
      * @return Resource id for the user comment input label in the crash dialog.
      *         If not provided, disables the input field.
      */


### PR DESCRIPTION
I did some minor changes to the code to allow the text of positive and negative buttons of CrashReportDialog to be customized.
