### PR TITLE
Customizing the Dialog

### DIFF
--- a/src/main/java/org/acra/ACRAConfiguration.java
+++ b/src/main/java/org/acra/ACRAConfiguration.java
@@ -83,6 +83,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     private Integer mResDialogIcon = null;
     private Integer mResDialogOkToast = null;
     private Integer mResDialogText = null;
+    private Integer mResDialogLayout = null;
     private Integer mResDialogTitle = null;
     private Integer mResNotifIcon = null;
     private Integer mResNotifText = null;
@@ -941,6 +942,19 @@ public class ACRAConfiguration implements ReportsCrashes {
 
         if (mReportsCrashes != null) {
             return mReportsCrashes.resDialogTitle();
+        }
+
+        return DEFAULT_RES_VALUE;
+    }
+
+    @Override
+    public int resDialogLayout() {
+        if (mResDialogLayout != null) {
+            return mResDialogLayout;
+        }
+
+        if (mReportsCrashes != null) {
+            return mReportsCrashes.resDialogLayout();
         }
 
         return DEFAULT_RES_VALUE;

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -134,6 +134,11 @@ public @interface ReportsCrashes {
     int resDialogTitle() default ACRAConstants.DEFAULT_RES_VALUE;
 
     /**
+     * @return Resource id for the layout in the crash dialog.
+     */
+    int resDialogLayout() default ACRAConstants.DEFAULT_RES_VALUE;
+
+    /**
      * @return Resource id for the icon in the status bar notification. Default
      *         is the system error notification icon.
      */


### PR DESCRIPTION
I would like to customize the ACTA Dialog in that way how your library is currently written it is required to edit your source files, which makes it less portable.

I implemented a Factory (`DialogBuilderFactory`) to inject a custom dialog builder and an option to define a layout which should been used for asking the user for feedback directly in the ACRA annotation with `resDialogLayout`.

I made it also possible to put buttons into the custom layout, it has to use the id `android.R.id.button1` for the positive (send) button and `android.R.id.button2` for a negative (cancel) button.
