### PR TITLE
Reverse order of log statement and invoking uncaughtException handler

### DIFF
--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -441,8 +441,8 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
             // If using silent mode, let the system default handler do it's job
             // and display the force close dialog.
             if (mDfltExceptionHandler != null) {
-                mDfltExceptionHandler.uncaughtException(brokenThread, unhandledThrowable);
                 Log.d(ACRA.LOG_TAG, "Handing Exception on to default ExceptionHandler");
+                mDfltExceptionHandler.uncaughtException(brokenThread, unhandledThrowable);
             } else {
                 Log.w(ACRA.LOG_TAG, "NOT Handing Exception on to default ExceptionHandler - non configured");
             }


### PR DESCRIPTION
It doesn't do any good to attempt to log a message after we've
terminated the thread.
