### PR TITLE
Make sending reports at shutdown configurable

### DIFF
--- a/src/main/java/org/acra/ACRAConfiguration.java
+++ b/src/main/java/org/acra/ACRAConfiguration.java
@@ -32,6 +32,7 @@ import static org.acra.ACRAConstants.DEFAULT_MAX_NUMBER_OF_REQUEST_RETRIES;
 import static org.acra.ACRAConstants.DEFAULT_NOTIFICATION_ICON;
 import static org.acra.ACRAConstants.DEFAULT_RES_VALUE;
 import static org.acra.ACRAConstants.DEFAULT_SEND_REPORTS_IN_DEV_MODE;
+import static org.acra.ACRAConstants.DEFAULT_SEND_REPORTS_AT_SHUTDOWN;
 import static org.acra.ACRAConstants.DEFAULT_SHARED_PREFERENCES_MODE;
 import static org.acra.ACRAConstants.DEFAULT_SOCKET_TIMEOUT;
 import static org.acra.ACRAConstants.DEFAULT_STRING_VALUE;
@@ -94,6 +95,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     private Integer mSocketTimeout = null;
     private Boolean mLogcatFilterByPid = null;
     private Boolean mSendReportsInDevMode = null;
+    private Boolean mSendReportsAtShutdown = null;
 
     private String[] mExcludeMatchingSharedPreferencesKeys = null;
     private String[] mExcludeMatchingSettingsKeys = null;
@@ -506,6 +508,18 @@ public class ACRAConfiguration implements ReportsCrashes {
      */
     public ACRAConfiguration setSendReportsInDevMode(Boolean sendReportsInDevMode) {
         mSendReportsInDevMode = sendReportsInDevMode;
+        return this;
+    }
+
+    /**
+     * 
+     * @param sendReportsAtShutdown
+     *            false if you want to disable sending reports at the time the
+     *            exception is caught. Reports will be sent when the application
+     *            is restarted.
+     */
+    public ACRAConfiguration setSendReportsAtShutdown(Boolean sendReportsAtShutdown) {
+        mSendReportsAtShutdown = sendReportsAtShutdown;
         return this;
     }
 
@@ -1074,6 +1088,19 @@ public class ACRAConfiguration implements ReportsCrashes {
         }
 
         return DEFAULT_SEND_REPORTS_IN_DEV_MODE;
+    }
+
+    @Override
+    public boolean sendReportsAtShutdown() {
+        if (mSendReportsAtShutdown != null) {
+            return mSendReportsAtShutdown;
+        }
+
+        if (mReportsCrashes != null) {
+            return mReportsCrashes.sendReportsAtShutdown();
+        }
+
+        return DEFAULT_SEND_REPORTS_AT_SHUTDOWN;
     }
 
     @Override

--- a/src/main/java/org/acra/ACRAConstants.java
+++ b/src/main/java/org/acra/ACRAConstants.java
@@ -111,6 +111,8 @@ public final class ACRAConstants {
 
     public static final boolean DEFAULT_SEND_REPORTS_IN_DEV_MODE = true;
 
+    public static final boolean DEFAULT_SEND_REPORTS_AT_SHUTDOWN = true;
+
     public static final String DEFAULT_APPLICATION_LOGFILE = DEFAULT_STRING_VALUE;
 
     public static final int DEFAULT_APPLICATION_LOGFILE_LINES = DEFAULT_LOGCAT_LINES;

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -722,6 +722,10 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
         final String reportFileName = getReportFileName(crashReportData);
         saveCrashReportFile(reportFileName, crashReportData);
 
+        if (endApplication && !ACRA.getConfig().sendReportsAtShutdown()) {
+            endApplication();
+        }
+
         SendWorker sender = null;
 
         if (reportingInteractionMode == ReportingInteractionMode.SILENT

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -479,6 +479,15 @@ public @interface ReportsCrashes {
     boolean sendReportsInDevMode() default ACRAConstants.DEFAULT_SEND_REPORTS_IN_DEV_MODE;
 
     /**
+     * Set this to false if you want to disable sending reports at the time the
+     * exception is caught. In thie case, reports will not be sent until the
+     * application is restarted.
+     *
+     * @return false if reports should not be sent.
+     */
+    boolean sendReportsAtShutdown() default ACRAConstants.DEFAULT_SEND_REPORTS_AT_SHUTDOWN;
+
+    /**
      * Provide here regex patterns to be evaluated on each SharedPreference key
      * to exclude KV pairs from the collected SharedPreferences. This allows you
      * to exclude sensitive user data like passwords to be collected.


### PR DESCRIPTION
The new Android Runtime, default as of Android 5.0, does not allow
spawning of threads during shutdown, and doing so raises
an exception:

  java.lang.InternalError: Thread starting during runtime shutdown

For reasons I don't fully understand, it appears the the shutdown
begins before ACRA even re-raises the exception. So the fact that
ACRA waits on the SendWorker is insufficient to prevent this issue
from occurring. For example, see issue #136, which in theory should
not occur.

This option allows ACRA to be configured to terminate immediately
after persisting the report to disk. The report is then sent
(per usual) when the application is restarted.
