### PR TITLE
Prevent potential race-condition when sending reports at startup

### DIFF
--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -132,7 +132,27 @@ public class ACRA {
      * @param config    ACRAConfiguration to manually set up ACRA configuration.
      * @throws IllegalStateException if it is called more than once.
      */
-    public static void init(Application app, ACRAConfiguration config){
+    public static void init(Application app, ACRAConfiguration config) {
+        init(app, config, true);
+    }
+
+    /**
+     * <p>
+     * Initialize ACRA for a given Application. The call to this method should
+     * be placed as soon as possible in the {@link Application#onCreate()}
+     * method.
+     * </p>
+     *
+     * @param app       Your Application class.
+     * @param config    ACRAConfiguration to manually set up ACRA configuration.
+     * @param checkReportsOnApplicationStart    Whether to invoke
+     *     ErrorReporter.checkReportsOnApplicationStart(). Apps which adjust the
+     *     ReportSenders should set this to false and call
+     *     checkReportsOnApplicationStart() themselves to prevent a potential
+     *     race with the SendWorker and list of ReportSenders.
+     * @throws IllegalStateException if it is called more than once.
+     */
+    public static void init(Application app, ACRAConfiguration config, boolean checkReportsOnApplicationStart){
 
         if (mApplication != null) {
             log.w(LOG_TAG, "ACRA#init called more than once. Won't do anything more.");
@@ -161,6 +181,11 @@ public class ACRA {
             errorReporter.setDefaultReportSenders();
 
             errorReporterSingleton = errorReporter;
+
+            // Check for pending reports
+            if (checkReportsOnApplicationStart) {
+                errorReporter.checkReportsOnApplicationStart();
+            }
 
         } catch (ACRAConfigurationException e) {
             log.w(LOG_TAG, "Error : ", e);

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -208,9 +208,6 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
         // Don't do it twice to avoid losing the original handler.
         mDfltExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(this);
-
-        // Check for pending reports
-        checkReportsOnApplicationStart();
     }
 
     /**


### PR DESCRIPTION
In theory, the SendWorker() can start sending reports before
mReportSenders has been properly set. This is extremely unlikely
in practice due to the overhead of spawning a new thread and the
amount of code that is executed by the SendWorker before it needs
to access mReportSenders.

But we can prevent the race from occuring in theory as well as in
practice by deferring calling checkReportsOnApplicationStart()
till after mReportSenders has been set.

https://github.com/ACRA/acra/issues/200
