### PR TITLE
Add config parameter to checkCrashResources

### DIFF
--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -169,7 +169,7 @@ public class ACRA {
         final SharedPreferences prefs = getACRASharedPreferences();
 
         try {
-            checkCrashResources();
+            checkCrashResources(config);
 
             log.d(LOG_TAG, "ACRA is enabled for " + mApplication.getPackageName() + ", intializing...");
 
@@ -253,8 +253,7 @@ public class ACRA {
      * @throws ACRAConfigurationException
      *             if required values are missing.
      */
-    static void checkCrashResources() throws ACRAConfigurationException {
-        ReportsCrashes conf = getConfig();
+    static void checkCrashResources(ReportsCrashes conf) throws ACRAConfigurationException {
         switch (conf.mode()) {
         case TOAST:
             if (conf.resToastText() == 0) {

--- a/src/main/java/org/acra/ACRAConfiguration.java
+++ b/src/main/java/org/acra/ACRAConfiguration.java
@@ -302,7 +302,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setMode(ReportingInteractionMode mode) throws ACRAConfigurationException {
         this.mMode = mode;
-        ACRA.checkCrashResources();
+        ACRA.checkCrashResources(this);
         return this;
     }
 


### PR DESCRIPTION
Calling setMode on ACRAConfiguration calls checkCrashResources on ACRA. However this does not provide a config parameter, which means that it checks against the current ACRA config. This will not really work when creating a config object for the annotation less configuration.