### PR TITLE
Fix javadoc issues preventing compilation with Java 8

### DIFF
--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -325,6 +325,7 @@ public class ACRA {
     }
 
     /**
+     * @param app       Your Application class.
      * @return new {@link ACRAConfiguration} instance with values initialized
      *         from the {@link ReportsCrashes} annotation.
      */

--- a/src/main/java/org/acra/ACRAConfiguration.java
+++ b/src/main/java/org/acra/ACRAConfiguration.java
@@ -100,6 +100,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param headers
      *            A map associating HTTP header names to their values.
+     * @return The updated ACRA configuration
      */
     public ACRAConfiguration setHttpHeaders(Map<String, String> headers) {
         this.mHttpHeaders = headers;
@@ -120,6 +121,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param additionalDropboxTags
      *            the additionalDropboxTags to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setAdditionalDropboxTags(String[] additionalDropboxTags) {
@@ -130,6 +132,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param additionalSharedPreferences
      *            the additionalSharedPreferences to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setAdditionalSharedPreferences(String[] additionalSharedPreferences) {
@@ -140,6 +143,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param connectionTimeout
      *            the connectionTimeout to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setConnectionTimeout(Integer connectionTimeout) {
@@ -150,6 +154,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param customReportContent
      *            the customReportContent to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setCustomReportContent(ReportField[] customReportContent) {
@@ -160,6 +165,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param deleteUnapprovedReportsOnApplicationStart
      *            the deleteUnapprovedReportsOnApplicationStart to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setDeleteUnapprovedReportsOnApplicationStart(Boolean deleteUnapprovedReportsOnApplicationStart) {
@@ -169,6 +175,7 @@ public class ACRAConfiguration implements ReportsCrashes {
 
     /**
      * @param deleteOldUnsentReportsOnApplicationStart    When to delete old (unsent) reports on startup.
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setDeleteOldUnsentReportsOnApplicationStart(Boolean deleteOldUnsentReportsOnApplicationStart) {
@@ -179,6 +186,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param dropboxCollectionMinutes
      *            the dropboxCollectionMinutes to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setDropboxCollectionMinutes(Integer dropboxCollectionMinutes) {
@@ -189,6 +197,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param forceCloseDialogAfterToast
      *            the forceCloseDialogAfterToast to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setForceCloseDialogAfterToast(Boolean forceCloseDialogAfterToast) {
@@ -204,6 +213,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param formKey
      *            the formKey to set
+     * @return The updated ACRA configuration
      */
     public ACRAConfiguration setFormKey(String formKey) {
         this.mFormKey = formKey;
@@ -218,6 +228,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param formUri
      *            the formUri to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setFormUri(String formUri) {
@@ -228,6 +239,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param formUriBasicAuthLogin
      *            the formUriBasicAuthLogin to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setFormUriBasicAuthLogin(String formUriBasicAuthLogin) {
@@ -238,6 +250,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param formUriBasicAuthPassword
      *            the formUriBasicAuthPassword to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setFormUriBasicAuthPassword(String formUriBasicAuthPassword) {
@@ -248,6 +261,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param includeDropboxSystemTags
      *            the includeDropboxSystemTags to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setIncludeDropboxSystemTags(Boolean includeDropboxSystemTags) {
@@ -258,6 +272,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param logcatArguments
      *            the logcatArguments to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setLogcatArguments(String[] logcatArguments) {
@@ -273,6 +288,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param mailTo
      *            the mailTo to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setMailTo(String mailTo) {
@@ -283,6 +299,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param maxNumberOfRequestRetries
      *            the maxNumberOfRequestRetries to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setMaxNumberOfRequestRetries(Integer maxNumberOfRequestRetries) {
@@ -296,6 +313,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param mode
      *            the new mode to set.
+     * @return The updated ACRA configuration
      * @throws ACRAConfigurationException
      *             if a configuration item is missing for this mode.
      */
@@ -324,6 +342,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see
      *            {@link ReportsCrashes#resDialogCommentPrompt()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResDialogCommentPrompt(int resId) {
@@ -339,6 +358,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see
      *            {@link ReportsCrashes#resDialogEmailPrompt()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResDialogEmailPrompt(int resId) {
@@ -353,6 +373,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resDialogIcon()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResDialogIcon(int resId) {
@@ -367,6 +388,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resDialogOkToast()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResDialogOkToast(int resId) {
@@ -381,6 +403,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resDialogText()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResDialogText(int resId) {
@@ -395,6 +418,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resDialogTitle()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResDialogTitle(int resId) {
@@ -409,6 +433,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resNotifIcon()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResNotifIcon(int resId) {
@@ -423,6 +448,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resNotifText()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResNotifText(int resId) {
@@ -438,6 +464,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param resId
      *            The resource id, see
      *            {@link ReportsCrashes#resNotifTickerText()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResNotifTickerText(int resId) {
@@ -452,6 +479,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resNotifTitle()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResNotifTitle(int resId) {
@@ -466,6 +494,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param resId
      *            The resource id, see {@link ReportsCrashes#resToastText()}
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResToastText(int resId) {
@@ -476,6 +505,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param sharedPreferenceMode
      *            the sharedPreferenceMode to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setSharedPreferenceMode(Integer sharedPreferenceMode) {
@@ -486,6 +516,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param sharedPreferenceName
      *            the sharedPreferenceName to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setSharedPreferenceName(String sharedPreferenceName) {
@@ -496,6 +527,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     /**
      * @param socketTimeout
      *            the socketTimeout to set
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setSocketTimeout(Integer socketTimeout) {
@@ -508,6 +540,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param filterByPid
      *            true if you want to collect only logcat lines related to your
      *            application process.
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setLogcatFilterByPid(Boolean filterByPid) {
@@ -520,6 +553,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param sendReportsInDevMode
      *            false if you want to disable sending reports in development
      *            mode. Reports will be sent only on signed applications.
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setSendReportsInDevMode(Boolean sendReportsInDevMode) {
@@ -533,6 +567,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            false if you want to disable sending reports at the time the
      *            exception is caught. Reports will be sent when the application
      *            is restarted.
+     * @return The updated ACRA configuration
      */
     public ACRAConfiguration setSendReportsAtShutdown(Boolean sendReportsAtShutdown) {
         mSendReportsAtShutdown = sendReportsAtShutdown;
@@ -545,6 +580,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            an array of Strings containing regexp defining
      *            SharedPreferences keys that should be excluded from the data
      *            collection.
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setExcludeMatchingSharedPreferencesKeys(String[] excludeMatchingSharedPreferencesKeys) {
@@ -558,6 +594,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            an array of Strings containing regexp defining
      *            Settings.System, Settings.Secure and Settings.Global keys that
      *            should be excluded from the data collection.
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setExcludeMatchingSettingsKeys(String[] excludeMatchingSettingsKeys) {
@@ -570,6 +607,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param applicationLogFile
      *            The path and file name of your application log file, to be
      *            used with {@link ReportField#APPLICATION_LOG}.
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setApplicationLogFile(String applicationLogFile) {
@@ -583,6 +621,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      *            The number of lines of your application log to be collected,
      *            to be used with {@link ReportField#APPLICATION_LOG} and
      *            {@link ReportsCrashes#applicationLogFile()}.
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setApplicationLogFileLines(int applicationLogFileLines) {
@@ -595,6 +634,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param disableSSLCertValidation
      *            Set this to true if you need to send reports to a server over
      *            SSL using a self-signed certificate.
+     * @return The updated ACRA configuration
      */
     public ACRAConfiguration setDisableSSLCertValidation(boolean disableSSLCertValidation) {
         mDisableSSLCertValidation = disableSSLCertValidation;
@@ -605,6 +645,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * 
      * @param httpMethod
      *            The method to be used to send data to the server.
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setHttpMethod(Method httpMethod) {
@@ -617,6 +658,7 @@ public class ACRAConfiguration implements ReportsCrashes {
      * @param type
      *            The type of content encoding to be used to send data to the
      *            server.
+     * @return The updated ACRA configuration
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setReportType(Type type) {

--- a/src/main/java/org/acra/ACRAConstants.java
+++ b/src/main/java/org/acra/ACRAConstants.java
@@ -21,7 +21,6 @@ import static org.acra.ReportField.*;
 
 /**
  * Responsible for collating those constants shared among the ACRA components.
- * <p/>
  * 
  * @author William Ferguson
  * @since 4.3.0

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -64,7 +64,8 @@ import static org.acra.ReportField.IS_SILENT;
  * <p>
  * When a crash occurs, it collects data of the crash context (device, system,
  * stack trace...) and writes a report file in the application private
- * directory. This report file is then sent :
+ * directory. This report file is then sent:
+ * </p>
  * <ul>
  * <li>immediately if {@link ReportsCrashes#mode} is set to
  * {@link ReportingInteractionMode#SILENT} or
@@ -74,7 +75,6 @@ import static org.acra.ReportField.IS_SILENT;
  * <li>when the user accepts to send it if {@link ReportsCrashes#mode()} is set
  * to {@link ReportingInteractionMode#NOTIFICATION}.</li>
  * </ul>
- * </p>
  * <p>
  * If an error occurs while sending a report, it is kept for later attempts.
  * </p>
@@ -277,18 +277,16 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
      * </p>
      * <p>
      * Example. Add to the {@link Application#onCreate()}:
-     *
+     * </p>
+     * 
      * <pre>
-     * {@code
      * ACRA.getErrorReporter().setExceptionHandlerInitializer(new ExceptionHandlerInitializer() {
      *     <code>@Override</code> public void initializeExceptionHandler(ErrorReporter reporter) {
      *         reporter.putCustomData("CUSTOM_ACCUMULATED_DATA_TAG", someAccumulatedData.toString);
      *     }
      * });
      * </pre>
-     *
-     * </p>
-     *
+     * 
      * @param initializer   The initializer. Can be <code>null</code>.
      */
     public void setExceptionHandlerInitializer(ExceptionHandlerInitializer initializer) {
@@ -654,6 +652,8 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
 
     /**
      * Creates a new crash report builder
+     *
+     * @return the newly created {@code ReportBuilder}
      */
     public ReportBuilder reportBuilder() {
         return new ReportBuilder();
@@ -1040,6 +1040,9 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
 
         /**
          * Set the error message to be reported.
+         *
+         * @param msg the error message
+         * @return the updated {@code ReportBuilder}
          */
         public ReportBuilder message(String msg) {
             mMessage = msg;
@@ -1048,6 +1051,9 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
 
         /**
          * Set the stack trace to be reported
+         *
+         * @param e The exception that should be associated with this report
+         * @return the updated {@code ReportBuilder}
          */
         public ReportBuilder exception(Throwable e) {
             mException = e;
@@ -1062,6 +1068,9 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
         /**
          * Sets additional values to be added to {@code CUSTOM_DATA}. Values
          * specified here take precedence over globally specified custom data.
+         *
+         * @param customData a map of custom key-values to be attached to the report
+         * @return the updated {@code ReportBuilder}
          */
         public ReportBuilder customData(Map<String, String> customData) {
             initCustomData();
@@ -1072,6 +1081,10 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
         /**
          * Sets an additional value to be added to {@code CUSTOM_DATA}. The value
          * specified here takes precedence over globally specified custom data.
+         *
+         * @param key the key identifying the custom data
+         * @param value the value for the custom data entry
+         * @return the updated {@code ReportBuilder}
          */
         public ReportBuilder customData(String key, String value) {
             initCustomData();
@@ -1081,6 +1094,8 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
 
         /**
          * Forces the report to be sent silently, ignoring the default interaction mode set in the config
+         *
+         * @return the updated {@code ReportBuilder}
          */
         public ReportBuilder forceSilent() {
             mForceSilent = true;
@@ -1089,6 +1104,8 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
 
         /**
          * Ends the application after sending the crash report
+         *
+         * @return the updated {@code ReportBuilder}
          */
         public ReportBuilder endsApplication() {
             mEndsApplication = true;

--- a/src/main/java/org/acra/ExceptionHandlerInitializer.java
+++ b/src/main/java/org/acra/ExceptionHandlerInitializer.java
@@ -6,14 +6,13 @@ package org.acra;
  * to add an additional initialization of the {@link ErrorReporter} before
  * exception is handled.
  * 
- * @see {@link ErrorReporter#setExceptionHandlerInitializer(ExceptionHandlerInitializer)}
- * 
+ * @see ErrorReporter#setExceptionHandlerInitializer(ExceptionHandlerInitializer)
  */
 public interface ExceptionHandlerInitializer {
     /**
      * Called before {@link ErrorReporter} handles the Exception.
      * 
-     * @param reporter
+     * @param reporter The {@link ErrorReporter} that will handle the exception
      */
     void initializeExceptionHandler(ErrorReporter reporter);
 }

--- a/src/main/java/org/acra/ReportField.java
+++ b/src/main/java/org/acra/ReportField.java
@@ -123,7 +123,7 @@ public enum ReportField {
      */
     STACK_TRACE,
     /**
-     * A hash of the stack trace, taking only method names into account.<br/>
+     * A hash of the stack trace, taking only method names into account.<br>
      * Line numbers are stripped out before computing the hash. This can help you
      * uniquely identify stack traces.
      */

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -70,6 +70,7 @@ public @interface ReportsCrashes {
      * </p>
      * <p>
      * Other modes have resources requirements:
+     * </p>
      * <ul>
      * <li>{@link ReportingInteractionMode#TOAST} requires
      * {@link #resToastText()} to be provided to define the text that you want
@@ -78,9 +79,10 @@ public @interface ReportsCrashes {
      * {@link #resNotifTickerText()}, {@link #resNotifTitle()},
      * {@link #resNotifText()}, {@link #resDialogText()}.</li>
      * <li>{@link ReportingInteractionMode#DIALOG} requires
-     * {@link #resDialogText()}</li>. Default is
-     * {@link ReportingInteractionMode#SILENT}
+     * {@link #resDialogText()}.</li>
      * </ul>
+     * <p>
+     * Default is {@link ReportingInteractionMode#SILENT}
      * </p>
      * 
      * @return the interaction mode that you want ACRA to implement.
@@ -288,7 +290,7 @@ public @interface ReportsCrashes {
      * <p>
      * Redefines the list of {@link ReportField}s collected and sent in your
      * reports. If you modify this list, you have to create a new Google Drive
-     * Spreadsheet & Form which will be based on these fields as column headers.
+     * Spreadsheet &amp; Form which will be based on these fields as column headers.
      * </p>
      * <p>
      * The fields order is significant. You can also use this property to modify
@@ -297,6 +299,7 @@ public @interface ReportsCrashes {
      * <p>
      * The default list is the following, except if you send reports by mail
      * using {@link #mailTo()}.
+     * </p>
      * <ul>
      * <li>
      * {@link ReportField#REPORT_ID}</li>
@@ -361,7 +364,6 @@ public @interface ReportsCrashes {
      * <li>
      * {@link ReportField#SETTINGS_GLOBAL}</li>
      * </ul>
-     * </p>
      * 
      * @return ReportField Array listing the fields to be included in the
      *         report.
@@ -374,6 +376,7 @@ public @interface ReportsCrashes {
      * email. This allows to get rid of the INTERNET permission. Reports content
      * can be customized with {@link #customReportContent()} . Default fields
      * are:
+     * </p>
      * <ul>
      * <li>
      * {@link ReportField#USER_COMMENT}</li>
@@ -390,7 +393,6 @@ public @interface ReportsCrashes {
      * <li>
      * {@link ReportField#STACK_TRACE}</li>
      * </ul>
-     * </p>
      * 
      * @return email address to which to send reports.
      */
@@ -544,6 +546,8 @@ public @interface ReportsCrashes {
      * <p>
      * The {@link Method} to be used when posting with {@link #formKey()}.
      * </p>
+     *
+     * @return HTTP method used when posting reports.
      */
     Method httpMethod() default Method.POST;
 

--- a/src/main/java/org/acra/collector/CrashReportDataFactory.java
+++ b/src/main/java/org/acra/collector/CrashReportDataFactory.java
@@ -124,8 +124,12 @@ public final class CrashReportDataFactory {
     /**
      * Collects crash data.
      *
+     * @param msg
+     *            A message to be associated with the crash report.
      * @param th
      *            Throwable that caused the crash.
+     * @param customData
+     *            Custom key/value pairs to be associated with the crash report.
      * @param isSilentReport
      *            Whether to report this report as being sent silently.
      * @param brokenThread  Thread on which the error occurred.

--- a/src/main/java/org/acra/collector/MediaCodecListCollector.java
+++ b/src/main/java/org/acra/collector/MediaCodecListCollector.java
@@ -133,7 +133,7 @@ public class MediaCodecListCollector {
      * with their capabilities (supported Color Formats, Codec Profiles et
      * Levels).
      * 
-     * @return
+     * @return The media codecs information
      */
     public static String collecMediaCodecList() {
         StringBuilder result = new StringBuilder();

--- a/src/main/java/org/acra/collector/ThreadCollector.java
+++ b/src/main/java/org/acra/collector/ThreadCollector.java
@@ -28,7 +28,7 @@ public class ThreadCollector {
      * Convenience method that collects some data identifying a Thread, usually the Thread which
      * crashed and returns a string containing the thread's id, name, priority and group name.
      * 
-     * @param the thread
+     * @param t the thread
      * @return a string representation of the string including the id, name and priority of the thread.
      */
     public static String collect(Thread t) {

--- a/src/main/java/org/acra/jraf/android/util/activitylifecyclecallbackscompat/ApplicationHelper.java
+++ b/src/main/java/org/acra/jraf/android/util/activitylifecyclecallbackscompat/ApplicationHelper.java
@@ -32,7 +32,7 @@ import android.os.Build;
 /**
  * Helper for accessing {@link Application#registerActivityLifecycleCallbacks(ActivityLifecycleCallbacks)} and
  * {@link Application#unregisterActivityLifecycleCallbacks(ActivityLifecycleCallbacks)} introduced in API level 14 in a
- * backwards compatible fashion.<br/>
+ * backwards compatible fashion.<br>
  * When running on API level 14 or above, the framework's implementations of these methods will be used.
  */
 public class ApplicationHelper {

--- a/src/main/java/org/acra/sender/HttpSender.java
+++ b/src/main/java/org/acra/sender/HttpSender.java
@@ -88,7 +88,7 @@ public class HttpSender implements ReportSender {
     public enum Type {
         /**
          * Send data as a www form encoded list of key/values.
-         * {@see http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4}
+         * @see <a href="http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4">Form content types</a>
          */
         FORM {
             @Override

--- a/src/main/java/org/acra/sender/ReportSender.java
+++ b/src/main/java/org/acra/sender/ReportSender.java
@@ -23,7 +23,7 @@ import org.acra.collector.CrashReportData;
  * {@link HttpSender} to send reports to your custom server-side report
  * collection script even if you expect (or prefer) specific names for each
  * report field as {@link HttpSender#send(Context, CrashReportData)}
- * can take a Map<ReportField, String> as an input to convert each field name to
+ * can take a {@code Map<ReportField, String>} as an input to convert each field name to
  * your preferred POST parameter name.
  * 
  * @author Kevin Gaudin


### PR DESCRIPTION
Java 8 enables some strict rule checking with doclint that breaks maven compilation when it raises errors. This commit fixes those errors, as well as warnings raised for missing javadoc tags.