### PR TITLE
Remove backwards incompatible change introduced by #210

### DIFF
--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -419,7 +419,6 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
 
             // Generate and send crash report
             reportBuilder()
-                .message("Uncaught exception")
                 .exception(e)
                 .endsApplication()
                 .send();


### PR DESCRIPTION
Previously, `Uncaught exception\n` was not prepended to the
stacktrace and existing receivers may not be expecting it.
This change was introduced by #210 (nee #83).

If clients want to include a message before the stack trace,
they may still do so, but it should not be forced there
unconditionally.