### PR TITLE
Add ability to have custom CrashReportDialog v2

### DIFF
--- a/src/main/java/org/acra/ACRAConfiguration.java
+++ b/src/main/java/org/acra/ACRAConfiguration.java
@@ -59,6 +59,7 @@ public class ACRAConfiguration implements ReportsCrashes {
     private Integer mMaxNumberOfRequestRetries = null;
     private ReportingInteractionMode mMode = null;
     private ReportsCrashes mReportsCrashes = null;
+    private Class<? extends BaseCrashReportDialog> mReportDialogClass = null;
 
     private Integer mResDialogPositiveButtonText = null;
     private Integer mResDialogNegativeButtonText = null;
@@ -317,6 +318,12 @@ public class ACRAConfiguration implements ReportsCrashes {
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setResDialogNegativeButtonText(int resId) {
         mResDialogNegativeButtonText = resId;
+        return this;
+    }
+
+    @SuppressWarnings( "unused" )
+    public ACRAConfiguration setReportDialogClass(Class<? extends BaseCrashReportDialog> reportDialogClass) {
+        mReportDialogClass = reportDialogClass;
         return this;
     }
 
@@ -1214,6 +1221,20 @@ public class ACRAConfiguration implements ReportsCrashes {
         }
 
         return null;
+    }
+
+
+    @Override
+    public Class reportDialogClass() {
+        if (mReportDialogClass != null) {
+            return mReportDialogClass;
+        }
+
+        if (mReportsCrashes != null) {
+            return mReportsCrashes.reportDialogClass();
+        }
+
+        return CrashReportDialog.class;
     }
 
     /**

--- a/src/main/java/org/acra/BaseCrashReportDialog.java
+++ b/src/main/java/org/acra/BaseCrashReportDialog.java
@@ -1,0 +1,93 @@
+package org.acra;
+
+import android.app.Activity;
+import android.app.NotificationManager;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Toast;
+
+import org.acra.collector.CrashReportData;
+import org.acra.util.ToastSender;
+
+import java.io.IOException;
+
+import static org.acra.ACRA.LOG_TAG;
+import static org.acra.ReportField.USER_COMMENT;
+import static org.acra.ReportField.USER_EMAIL;
+
+/**
+ * Activity which implements the base functionality for a CrashReportDialog
+ * Activities which extend from this class can override onCreate() to create a custom view,
+ * but they must call super.onCreate() at the beginning of the method.
+ *
+ * The methods sendCrash(comment, usrEmail) and cancelReports() can be used to send or cancel
+ * sending of reports respectively.
+ */
+public class BaseCrashReportDialog extends Activity {
+    String mReportFileName;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        boolean forceCancel = getIntent().getBooleanExtra(ACRAConstants.EXTRA_FORCE_CANCEL, false);
+        if (forceCancel) {
+            ACRA.log.d(ACRA.LOG_TAG, "Forced reports deletion.");
+            cancelReports();
+            finish();
+            return;
+        }
+
+        mReportFileName = getIntent().getStringExtra(ACRAConstants.EXTRA_REPORT_FILE_NAME);
+        Log.d(LOG_TAG, "Opening CrashReportDialog for " + mReportFileName);
+        if (mReportFileName == null) {
+            finish();
+        }
+        cancelNotification();
+    }
+
+
+    /**
+     * Disable the notification in the Status Bar.
+     */
+    private void cancelNotification() {
+        final NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        notificationManager.cancel(ACRAConstants.NOTIF_CRASH_ID);
+    }
+
+
+    /**
+     * Cancel any pending crash reports
+     */
+    protected void cancelReports() {
+        ACRA.getErrorReporter().deletePendingNonApprovedReports(false);
+    }
+
+
+    /**
+     * Send crash report given user's comment and email address. If none should be empty strings
+     * @param comment
+     * @param usrEmail
+     */
+    protected void sendCrash(String comment, String usrEmail) {
+        final CrashReportPersister persister = new CrashReportPersister(getApplicationContext());
+        try {
+            Log.d(LOG_TAG, "Add user comment to " + mReportFileName);
+            final CrashReportData crashData = persister.load(mReportFileName);
+            crashData.put(USER_COMMENT, comment);
+            crashData.put(USER_EMAIL, usrEmail);
+            persister.store(crashData, mReportFileName);
+        } catch (IOException e) {
+            Log.w(LOG_TAG, "User comment not added: ", e);
+        }
+
+        // Start the report sending task
+        Log.v(ACRA.LOG_TAG, "About to start SenderWorker from CrashReportDialog");
+        ACRA.getErrorReporter().startSendingReports(false, true);
+
+        // Optional Toast to thank the user
+        final int toastId = ACRA.getConfig().resDialogOkToast();
+        if (toastId != 0) {
+            ToastSender.sendToast(getApplicationContext(), toastId, Toast.LENGTH_LONG);
+        }
+    }
+}

--- a/src/main/java/org/acra/CrashReportDialog.java
+++ b/src/main/java/org/acra/CrashReportDialog.java
@@ -1,62 +1,36 @@
 package org.acra;
 
-import static org.acra.ACRA.LOG_TAG;
-import static org.acra.ReportField.USER_COMMENT;
-import static org.acra.ReportField.USER_EMAIL;
-
-import java.io.IOException;
-
-import org.acra.collector.CrashReportData;
-import org.acra.util.ToastSender;
-
-import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.NotificationManager;
 import android.content.DialogInterface;
-import android.content.DialogInterface.OnDismissListener;
 import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
 import android.os.Bundle;
 import android.text.InputType;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
-import android.widget.Toast;
+
 
 /**
  * This is the dialog Activity used by ACRA to get authorization from the user
  * to send reports. Requires android:launchMode="singleInstance" in your
  * AndroidManifest to work properly.
  **/
-public class CrashReportDialog extends Activity implements DialogInterface.OnClickListener, OnDismissListener {
+public class CrashReportDialog extends BaseCrashReportDialog implements DialogInterface.OnClickListener, DialogInterface.OnDismissListener {
     private static final String STATE_EMAIL = "email";
     private static final String STATE_COMMENT = "comment";
     private SharedPreferences prefs;
     private EditText userComment;
     private EditText userEmail;
-    String mReportFileName;
+
     AlertDialog mDialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        boolean forceCancel = getIntent().getBooleanExtra(ACRAConstants.EXTRA_FORCE_CANCEL, false);
-        if(forceCancel) {
-            ACRA.log.d(ACRA.LOG_TAG, "Forced reports deletion.");
-            cancelReports();
-            finish();
-            return;
-        }
 
-        mReportFileName = getIntent().getStringExtra(ACRAConstants.EXTRA_REPORT_FILE_NAME);
-        Log.d(LOG_TAG, "Opening CrashReportDialog for " + mReportFileName);
-        if (mReportFileName == null) {
-            finish();
-        }
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(this);
         int resourceId = ACRA.getConfig().resDialogTitle();
         if(resourceId != 0) {
@@ -69,14 +43,14 @@ public class CrashReportDialog extends Activity implements DialogInterface.OnCli
         dialogBuilder.setView(buildCustomView(savedInstanceState));
         dialogBuilder.setPositiveButton(getText(ACRA.getConfig().resDialogPositiveButtonText()), CrashReportDialog.this);
         dialogBuilder.setNegativeButton(getText(ACRA.getConfig().resDialogNegativeButtonText()), CrashReportDialog.this);
-        cancelNotification();
+
         mDialog = dialogBuilder.create();
         mDialog.setCanceledOnTouchOutside(false);
         mDialog.setOnDismissListener(this);
         mDialog.show();
     }
 
-    private View buildCustomView(Bundle savedInstanceState) {
+    protected View buildCustomView(Bundle savedInstanceState) {
         final LinearLayout root = new LinearLayout(this);
         root.setOrientation(LinearLayout.VERTICAL);
         root.setPadding(10, 10, 10, 10);
@@ -148,63 +122,34 @@ public class CrashReportDialog extends Activity implements DialogInterface.OnCli
         return root;
     }
 
-    /**
-     * Disable the notification in the Status Bar.
-     */
-    protected void cancelNotification() {
-        final NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-        notificationManager.cancel(ACRAConstants.NOTIF_CRASH_ID);
-    }
-
     @Override
     public void onClick(DialogInterface dialog, int which) {
-        if (which == DialogInterface.BUTTON_POSITIVE)
-            sendCrash();
-        else {
+        if (which == DialogInterface.BUTTON_POSITIVE) {
+            // Retrieve user comment
+            final String comment = userComment != null ? userComment.getText().toString() : "";
+
+            // Store the user email
+            final String usrEmail;
+            if (prefs != null && userEmail != null) {
+                usrEmail = userEmail.getText().toString();
+                final SharedPreferences.Editor prefEditor = prefs.edit();
+                prefEditor.putString(ACRA.PREF_USER_EMAIL_ADDRESS, usrEmail);
+                prefEditor.commit();
+            } else {
+                usrEmail = "";
+            }
+            sendCrash(comment, usrEmail);
+        } else {
             cancelReports();
         }
+
         finish();
     }
 
-    private void cancelReports() {
-        ACRA.getErrorReporter().deletePendingNonApprovedReports(false);
-    }
 
-    private void sendCrash() {
-        // Retrieve user comment
-        final String comment = userComment != null ? userComment.getText().toString() : "";
-
-        // Store the user email
-        final String usrEmail;
-        if (prefs != null && userEmail != null) {
-            usrEmail = userEmail.getText().toString();
-            final Editor prefEditor = prefs.edit();
-            prefEditor.putString(ACRA.PREF_USER_EMAIL_ADDRESS, usrEmail);
-            prefEditor.commit();
-        } else {
-            usrEmail = "";
-        }
-
-        final CrashReportPersister persister = new CrashReportPersister(getApplicationContext());
-        try {
-            Log.d(LOG_TAG, "Add user comment to " + mReportFileName);
-            final CrashReportData crashData = persister.load(mReportFileName);
-            crashData.put(USER_COMMENT, comment);
-            crashData.put(USER_EMAIL, usrEmail);
-            persister.store(crashData, mReportFileName);
-        } catch (IOException e) {
-            Log.w(LOG_TAG, "User comment not added: ", e);
-        }
-
-        // Start the report sending task
-        Log.v(ACRA.LOG_TAG, "About to start SenderWorker from CrashReportDialog");
-        ACRA.getErrorReporter().startSendingReports(false, true);
-
-        // Optional Toast to thank the user
-        final int toastId = ACRA.getConfig().resDialogOkToast();
-        if (toastId != 0) {
-            ToastSender.sendToast(getApplicationContext(), toastId, Toast.LENGTH_LONG);
-        }
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        finish();
     }
 
     /*
@@ -221,10 +166,5 @@ public class CrashReportDialog extends Activity implements DialogInterface.OnCli
         if (userEmail != null && userEmail.getText() != null) {
             outState.putString(STATE_EMAIL, userEmail.getText().toString());
         }
-    }
-
-    @Override
-    public void onDismiss(DialogInterface dialog) {
-        finish();
     }
 }

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -154,7 +154,7 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
                 public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
                     if (ACRA.DEV_LOGGING)
                         ACRA.log.d(ACRA.LOG_TAG, "onActivityCreated " + activity.getClass());
-                    if (!(activity instanceof CrashReportDialog)) {
+                    if (!(activity instanceof BaseCrashReportDialog)) {
                         // Ignore CrashReportDialog because we want the last
                         // application Activity that was started so that we can
                         // explicitly kill it off.
@@ -859,7 +859,7 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
      */
     void notifyDialog(String reportFileName) {
         Log.d(LOG_TAG, "Creating Dialog for " + reportFileName);
-        Intent dialogIntent = new Intent(mContext, CrashReportDialog.class);
+        Intent dialogIntent = new Intent(mContext, ACRA.getConfig().reportDialogClass());
         dialogIntent.putExtra(ACRAConstants.EXTRA_REPORT_FILE_NAME, reportFileName);
         dialogIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         mContext.startActivity(dialogIntent);

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -24,6 +24,8 @@ import java.lang.annotation.Target;
 
 import org.acra.ACRA;
 import org.acra.ACRAConstants;
+import org.acra.BaseCrashReportDialog;
+import org.acra.CrashReportDialog;
 import org.acra.ReportField;
 import org.acra.ReportingInteractionMode;
 import org.acra.sender.HttpSender.Method;
@@ -536,6 +538,12 @@ public @interface ReportsCrashes {
     boolean disableSSLCertValidation() default ACRAConstants.DEFAULT_DISABLE_SSL_CERT_VALIDATION;
 
     String httpsSocketFactoryFactoryClass() default ACRAConstants.DEFAULT_HTTP_SOCKET_FACTORY_FACTORY_CLASS;
+
+    /**
+     * @return Class for the CrashReportDialog used when sending intent.
+     *  If not provided, defaults to CrashReportDialog.class
+     */
+    Class<? extends BaseCrashReportDialog> reportDialogClass() default CrashReportDialog.class;
 
     /**
      * <p>


### PR DESCRIPTION
Continuing on from #218, I've created a new base class for `CrashReportDialog` which implements the minimum functionality for sending a crash report, and allowed setting of an arbitrary Activity for the CrashReportActivity