### PR TITLE
Update SharedPreferencesCollector.java

### DIFF
--- a/src/main/java/org/acra/collector/SharedPreferencesCollector.java
+++ b/src/main/java/org/acra/collector/SharedPreferencesCollector.java
@@ -48,7 +48,7 @@ final class SharedPreferencesCollector {
     public static String collect(Context context) {
         final StringBuilder result = new StringBuilder();
         final Map<String, SharedPreferences> shrdPrefs = new TreeMap<String, SharedPreferences>();
-        shrdPrefs.put("default", PreferenceManager.getDefaultSharedPreferences(context));
+        shrdPrefs.put("default", ACRA.getACRASharedPreferences());
         final String[] shrdPrefsIds = ACRA.getConfig().additionalSharedPreferences();
         if (shrdPrefsIds != null) {
             for (final String shrdPrefId : shrdPrefsIds) {


### PR DESCRIPTION
Fix collection of custom shared preferences. Currently the (incorrect) system default `SharedPreferences` are being sent when using custom `sharedPreferencesName`