### PR TITLE
Do not use getPackageName() when looking for BuildConfig class

### DIFF
--- a/src/main/java/org/acra/collector/CrashReportDataFactory.java
+++ b/src/main/java/org/acra/collector/CrashReportDataFactory.java
@@ -238,7 +238,7 @@ public final class CrashReportDataFactory {
             }
 
             if (crashReportFields.contains(BUILD_CONFIG)) {
-                final String className = context.getPackageName() + ".BuildConfig";
+                final String className = context.getClass().getPackage().getName() + ".BuildConfig";
                 try {
                     final Class<?> buildConfig = Class.forName(className);
                     crashReportData.put(BUILD_CONFIG, ReflectionCollector.collectConstants(buildConfig));


### PR DESCRIPTION
`context.getPackageName() + ".BuildConfig";` will not work if using applicationIdSuffix or applicationId is different than the application source package name. 

Example:

- you have `org.acra.sample` as package name in your source code,
- you have 2 flavors _free_ and _pro_ with applicationId `org.acra.sample.free` and `org.acra.sample.pro` respectively,

When you build the _free_ flavor the `context.getPackageName()` will return `org.acra.sample.free` but BuildConfig will be based on your source code package name not the applicationId therefore will be located at `org.acra.sample.BuildConfig`. 

Since ACRA is initialized in the Application class we can get the name of the source code package name to get the location of BuildConfig.

