### PR TITLE
Fix check for whether to gather read logs. Has permission if either READ_LOGS_PERMISSION or API >= 16.

### DIFF
--- a/src/main/java/org/acra/collector/CrashReportDataFactory.java
+++ b/src/main/java/org/acra/collector/CrashReportDataFactory.java
@@ -312,9 +312,8 @@ public final class CrashReportDataFactory {
             // Before JellyBean, this required the READ_LOGS permission
             // Since JellyBean, READ_LOGS is not granted to third-party apps anymore for security reasons.
             // Though, we can call logcat without any permission and still get traces related to our app.
-            if (prefs.getBoolean(ACRA.PREF_ENABLE_SYSTEM_LOGS, true)
-                && (pm.hasPermission(Manifest.permission.READ_LOGS))
-                || Compatibility.getAPILevel() >= 16) {
+            final boolean hasReadLogsPermission = pm.hasPermission(Manifest.permission.READ_LOGS) || (Compatibility.getAPILevel() >= 16);
+            if (prefs.getBoolean(ACRA.PREF_ENABLE_SYSTEM_LOGS, true) && hasReadLogsPermission) {
                 Log.i(ACRA.LOG_TAG, "READ_LOGS granted! ACRA can include LogCat and DropBox data.");
                 if (crashReportFields.contains(LOGCAT)) {
                     crashReportData.put(LOGCAT, LogCatCollector.collectLogCat(null));


### PR DESCRIPTION
Fixes one of 2 issues raised in #236 