### PR TITLE
ACRA now supports back to API 3 once again.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<!--
+			NB ACRA supports back to API3.
+			But in order to compile classes and method that will NOT be used except when the target platform is of sufficient version
+			we need to compile against version 17.
+		-->
         <android.version>17</android.version>
 	</properties>
 
@@ -57,7 +63,7 @@
             <artifactId>android</artifactId>
             <version>4.1.1.4</version>
             <type>jar</type>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -123,6 +129,7 @@
 					</execution>
 				</executions>
                 <configuration>
+					<bootclasspath>${env.ANDROID_HOME}/platforms/android-${android.version}/android.jar</bootclasspath>
                     <excludePackageNames>org.acra.log,org.acra.util</excludePackageNames>
                 </configuration>
 			</plugin>

--- a/src/main/java/org/acra/CrashReportDialog.java
+++ b/src/main/java/org/acra/CrashReportDialog.java
@@ -54,12 +54,12 @@ public class CrashReportDialog extends BaseCrashReportDialog implements DialogIn
         final LinearLayout root = new LinearLayout(this);
         root.setOrientation(LinearLayout.VERTICAL);
         root.setPadding(10, 10, 10, 10);
-        root.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        root.setLayoutParams(new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
         root.setFocusable(true);
         root.setFocusableInTouchMode(true);
 
         final ScrollView scroll = new ScrollView(this);
-        root.addView(scroll, new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, 1.0f));
+        root.addView(scroll, new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT, 1.0f));
         final LinearLayout scrollable = new LinearLayout(this);
         scrollable.setOrientation(LinearLayout.VERTICAL);
         scroll.addView(scrollable);
@@ -78,8 +78,7 @@ public class CrashReportDialog extends BaseCrashReportDialog implements DialogIn
             label.setText(getText(commentPromptId));
 
             label.setPadding(label.getPaddingLeft(), 10, label.getPaddingRight(), label.getPaddingBottom());
-            scrollable.addView(label, new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT,
-                    LayoutParams.WRAP_CONTENT));
+            scrollable.addView(label, new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT));
 
             userCommentView = new EditText(this);
             userCommentView.setLines(2);

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -152,7 +152,7 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
         final Time appStartDate = new Time();
         appStartDate.setToNow();
 
-        if (Compatibility.getAPILevel() >= 14) { // ActivityLifecycleCallback
+        if (Compatibility.getAPILevel() >= Compatibility.VERSION_CODES.ICE_CREAM_SANDWICH) { // ActivityLifecycleCallback
             // only available for API14+
             ApplicationHelper.registerActivityLifecycleCallbacks(context, new ActivityLifecycleCallbacksCompat() {
                 @Override

--- a/src/main/java/org/acra/collector/Compatibility.java
+++ b/src/main/java/org/acra/collector/Compatibility.java
@@ -28,6 +28,15 @@ import java.lang.reflect.Field;
  */
 public final class Compatibility {
 
+    public class VERSION_CODES {
+        public final static int ECLAIR = 5;
+        public final static int FROYO = 8;
+        public final static int ICE_CREAM_SANDWICH = 14;
+        public final static int JELLY_BEAN = 16;
+        public final static int JELLY_BEAN_MR1 = 17;
+        public final static int LOLLIPOP = 21;
+    }
+
     /**
      * Retrieves Android SDK API level using the best possible method.
      * 

--- a/src/main/java/org/acra/collector/CrashReportDataFactory.java
+++ b/src/main/java/org/acra/collector/CrashReportDataFactory.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import android.text.TextUtils;
 import org.acra.ACRA;
 import org.acra.ReportField;
 import org.acra.util.Installation;
@@ -308,7 +309,7 @@ public final class CrashReportDataFactory {
             // Before JellyBean, this required the READ_LOGS permission
             // Since JellyBean, READ_LOGS is not granted to third-party apps anymore for security reasons.
             // Though, we can call logcat without any permission and still get traces related to our app.
-            final boolean hasReadLogsPermission = pm.hasPermission(Manifest.permission.READ_LOGS) || (Compatibility.getAPILevel() >= 16);
+            final boolean hasReadLogsPermission = pm.hasPermission(Manifest.permission.READ_LOGS) || (Compatibility.getAPILevel() >= Compatibility.VERSION_CODES.JELLY_BEAN);
             if (prefs.getBoolean(ACRA.PREF_ENABLE_SYSTEM_LOGS, true) && hasReadLogsPermission) {
                 ACRA.log.i(LOG_TAG, "READ_LOGS granted! ACRA can include LogCat and DropBox data.");
                 if (crashReportFields.contains(LOGCAT)) {
@@ -396,7 +397,7 @@ public final class CrashReportDataFactory {
         final Writer result = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(result);
 
-        if (msg != null && !msg.isEmpty())
+        if (msg != null && !TextUtils.isEmpty(msg))
             printWriter.println(msg);
 
         // If the exception was thrown in a background thread inside

--- a/src/main/java/org/acra/collector/DeviceFeaturesCollector.java
+++ b/src/main/java/org/acra/collector/DeviceFeaturesCollector.java
@@ -34,7 +34,7 @@ final class DeviceFeaturesCollector {
 
     public static String getFeatures(Context ctx) {
 
-        if (Compatibility.getAPILevel() < 5) {
+        if (Compatibility.getAPILevel() < Compatibility.VERSION_CODES.ECLAIR) {
             return "Data available only with API Level >= 5";
         }
 

--- a/src/main/java/org/acra/collector/DisplayManagerCollector.java
+++ b/src/main/java/org/acra/collector/DisplayManagerCollector.java
@@ -26,7 +26,7 @@ final class DisplayManagerCollector {
         Display[] displays = null;
         final StringBuilder result = new StringBuilder();
 
-        if (Compatibility.getAPILevel() < 17) {
+        if (Compatibility.getAPILevel() < Compatibility.VERSION_CODES.JELLY_BEAN_MR1) {
             // Before Android 4.2, there was a single display available from the
             // window manager
             final WindowManager windowManager = (WindowManager) ctx

--- a/src/main/java/org/acra/collector/LogCatCollector.java
+++ b/src/main/java/org/acra/collector/LogCatCollector.java
@@ -82,7 +82,7 @@ class LogCatCollector {
         final int tailIndex = logcatArgumentsList.indexOf("-t");
         if (tailIndex > -1 && tailIndex < logcatArgumentsList.size()) {
             tailCount = Integer.parseInt(logcatArgumentsList.get(tailIndex + 1));
-            if (Compatibility.getAPILevel() < 8) {
+            if (Compatibility.getAPILevel() < Compatibility.VERSION_CODES.FROYO) {
                 logcatArgumentsList.remove(tailIndex + 1);
                 logcatArgumentsList.remove(tailIndex);
                 logcatArgumentsList.add("-d");

--- a/src/main/java/org/acra/collector/SettingsCollector.java
+++ b/src/main/java/org/acra/collector/SettingsCollector.java
@@ -112,7 +112,7 @@ final class SettingsCollector {
      * @return A human readable String containing one key=value pair per line.
      */
     public static String collectGlobalSettings(Context ctx) {
-        if (Compatibility.getAPILevel() < 17) {
+        if (Compatibility.getAPILevel() < Compatibility.VERSION_CODES.JELLY_BEAN_MR1) {
             return "";
         }
 

--- a/src/main/java/org/acra/jraf/android/util/activitylifecyclecallbackscompat/ActivityLifecycleCallbacksWrapper.java
+++ b/src/main/java/org/acra/jraf/android/util/activitylifecyclecallbackscompat/ActivityLifecycleCallbacksWrapper.java
@@ -27,15 +27,14 @@ import android.app.Activity;
 import android.app.Application.ActivityLifecycleCallbacks;
 import android.os.Bundle;
 
-import java.util.concurrent.Callable;
-
 /**
  * Wraps an {@link ActivityLifecycleCallbacksCompat} into an {@link ActivityLifecycleCallbacks}.
  */
 /* package */class ActivityLifecycleCallbacksWrapper implements ActivityLifecycleCallbacks {
-    private org.acra.jraf.android.util.activitylifecyclecallbackscompat.ActivityLifecycleCallbacksCompat mCallback;
 
-    public ActivityLifecycleCallbacksWrapper(org.acra.jraf.android.util.activitylifecyclecallbackscompat.ActivityLifecycleCallbacksCompat callback) {
+    private final ActivityLifecycleCallbacksCompat mCallback;
+
+    public ActivityLifecycleCallbacksWrapper(ActivityLifecycleCallbacksCompat callback) {
         mCallback = callback;
     }
 
@@ -79,9 +78,10 @@ import java.util.concurrent.Callable;
      */
     @Override
     public boolean equals(Object object) {
-        if( !(object instanceof ActivityLifecycleCallbacksWrapper) )
+        if( !(object instanceof ActivityLifecycleCallbacksWrapper) ) {
             return false;
-        ActivityLifecycleCallbacksWrapper that = ( ActivityLifecycleCallbacksWrapper )object;
+        }
+        final ActivityLifecycleCallbacksWrapper that = (ActivityLifecycleCallbacksWrapper) object;
         return null == mCallback ? null == that.mCallback : mCallback.equals( that.mCallback );
     }
 

--- a/src/main/java/org/acra/jraf/android/util/activitylifecyclecallbackscompat/ApplicationHelper.java
+++ b/src/main/java/org/acra/jraf/android/util/activitylifecyclecallbackscompat/ApplicationHelper.java
@@ -23,24 +23,18 @@
  */
 package org.acra.jraf.android.util.activitylifecyclecallbackscompat;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
-import android.os.Build;
 
 /**
  * Helper for accessing {@link Application#registerActivityLifecycleCallbacks(ActivityLifecycleCallbacks)} and
  * {@link Application#unregisterActivityLifecycleCallbacks(ActivityLifecycleCallbacks)} introduced in API level 14 in a
  * backwards compatible fashion.<br>
+ *
  * When running on API level 14 or above, the framework's implementations of these methods will be used.
  */
-public class ApplicationHelper {
-    public static final boolean PRE_ICS = Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH;
-
-    /*
-     * Register.
-     */
+public final class ApplicationHelper {
 
     /**
      * Registers a callback to be called following the life cycle of the application's {@link Activity activities}.
@@ -49,19 +43,6 @@ public class ApplicationHelper {
      * @param callback The callback to register.
      */
     public static void registerActivityLifecycleCallbacks(Application application, ActivityLifecycleCallbacksCompat callback) {
-        if (PRE_ICS) {
-            preIcsRegisterActivityLifecycleCallbacks(callback);
-        } else {
-            postIcsRegisterActivityLifecycleCallbacks(application, callback);
-        }
-    }
-
-    private static void preIcsRegisterActivityLifecycleCallbacks(ActivityLifecycleCallbacksCompat callback) {
-        MainLifecycleDispatcher.get().registerActivityLifecycleCallbacks(callback);
-    }
-
-    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
-    private static void postIcsRegisterActivityLifecycleCallbacks(Application application, ActivityLifecycleCallbacksCompat callback) {
         application.registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacksWrapper(callback));
     }
 
@@ -77,20 +58,6 @@ public class ApplicationHelper {
      * @param callback The callback to unregister.
      */
     public void unregisterActivityLifecycleCallbacks(Application application, ActivityLifecycleCallbacksCompat callback) {
-        if (PRE_ICS) {
-            preIcsUnregisterActivityLifecycleCallbacks(callback);
-        } else {
-            postIcsUnregisterActivityLifecycleCallbacks(application, callback);
-        }
-    }
-
-    private static void preIcsUnregisterActivityLifecycleCallbacks(ActivityLifecycleCallbacksCompat callback) {
-        MainLifecycleDispatcher.get().unregisterActivityLifecycleCallbacks(callback);
-    }
-
-    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
-    private static void postIcsUnregisterActivityLifecycleCallbacks(Application application, ActivityLifecycleCallbacksCompat callback) {
         application.unregisterActivityLifecycleCallbacks(new ActivityLifecycleCallbacksWrapper(callback));
     }
-
 }

--- a/src/main/java/org/acra/util/TlsSniSocketFactory.java
+++ b/src/main/java/org/acra/util/TlsSniSocketFactory.java
@@ -7,12 +7,12 @@
  */
 package org.acra.util;
 
-import android.annotation.TargetApi;
 import android.net.SSLCertificateSocketFactory;
 import android.os.Build;
 import android.text.TextUtils;
 
 import org.acra.ACRA;
+import org.acra.collector.Compatibility;
 import org.apache.http.conn.scheme.LayeredSocketFactory;
 import org.apache.http.conn.ssl.BrowserCompatHostnameVerifier;
 import org.apache.http.params.HttpParams;
@@ -46,9 +46,6 @@ import javax.net.ssl.SSLSocket;
 public class TlsSniSocketFactory implements LayeredSocketFactory {
 
     private static final String TAG =  TlsSniSocketFactory.class.getSimpleName();
-    
-    private final static int VERSION_CODES_JELLY_BEAN_MR1 = 17;
-    private final static int VERSION_CODES_LOLLIPOP = 21;
     
     private final SSLCertificateSocketFactory sslSocketFactory = (SSLCertificateSocketFactory) SSLCertificateSocketFactory.getDefault(0);
 
@@ -163,7 +160,7 @@ public class TlsSniSocketFactory implements LayeredSocketFactory {
         socket.setEnabledProtocols(protocols.toArray(new String[protocols.size()]));
 
         /* set reasonable cipher suites */
-        if (Build.VERSION.SDK_INT < VERSION_CODES_LOLLIPOP) {
+        if (Compatibility.getAPILevel() < Compatibility.VERSION_CODES.LOLLIPOP) {
             // choose secure cipher suites
 
             final List<String> availableCiphers = Arrays.asList(socket.getSupportedCipherSuites());
@@ -183,10 +180,9 @@ public class TlsSniSocketFactory implements LayeredSocketFactory {
         }
     }
     
-    @TargetApi(VERSION_CODES_JELLY_BEAN_MR1)
     private void setSniHostname(SSLSocket socket, String hostName) {
         // set SNI host name
-        if (Build.VERSION.SDK_INT >= VERSION_CODES_JELLY_BEAN_MR1) {
+        if (Compatibility.getAPILevel() >= Compatibility.VERSION_CODES.JELLY_BEAN_MR1) {
             ACRA.log.d(TAG, "Using documented SNI with host name " + hostName);
             sslSocketFactory.setHostname(socket, hostName);
         } else {


### PR DESCRIPTION
Replaced String#isEmpty with TextUtils#isEmpty.
Removed/replaced other instances that would have stopped ACRA working with APIs between 3 and 9.

