### PR TITLE
Allowing authentication with crash server in pre Gingerbread apps.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Base64 library -->
+		<dependency>
+			<groupId>net.iharder</groupId>
+			<artifactId>base64</artifactId>
+			<version>2.3.8</version>
+		</dependency>
+
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -703,8 +703,7 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
         boolean sendOnlySilentReports = false;
         ReportingInteractionMode reportingInteractionMode;
         if (!reportBuilder.mForceSilent) {
-            // No interaction mode defined, we assume it has been set during
-            // ACRA.initACRA()
+            // No interaction mode defined in the ReportBuilder, we assume it has been set during ACRA.initACRA()
             reportingInteractionMode = ACRA.getConfig().mode();
         } else {
             reportingInteractionMode = ReportingInteractionMode.SILENT;

--- a/src/main/java/org/acra/util/HttpRequest.java
+++ b/src/main/java/org/acra/util/HttpRequest.java
@@ -5,6 +5,7 @@
  */
 package org.acra.util;
 
+import net.iharder.Base64;
 import org.acra.ACRA;
 import org.acra.sender.HttpSender.Method;
 import org.acra.sender.HttpSender.Type;
@@ -16,9 +17,7 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.Authenticator;
 import java.net.HttpURLConnection;
-import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
@@ -89,11 +88,9 @@ public final class HttpRequest {
 
         // Set Credentials
         if ((login != null) && (password != null)) {
-            Authenticator.setDefault(new Authenticator() {
-                protected PasswordAuthentication getPasswordAuthentication() {
-                    return new PasswordAuthentication(login, password.toCharArray());
-                }
-            });
+            final String credentials = login + ":" + password;
+            final String encoded = Base64.encodeBytes(credentials.getBytes("UTF-8"));
+            urlConnection.setRequestProperty("Authorization", "Basic " + encoded);
         }
 
         urlConnection.setConnectTimeout(connectionTimeOut);


### PR DESCRIPTION
Replaced Authenticator with Authorization Request property as pre Gingerbread versions of UrlConnection don't respect Authenticator.

Fix for #311 