### PR TITLE
FIX #327: SendWorker now works in the separate process service.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pom.xml.releaseBackup
 release.properties
 *.iml
 *.idea/*
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ android {
         versionCode 1
         versionName "1.0"
     }
-    
+
     buildTypes {
         release {
             minifyEnabled false
@@ -25,6 +25,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:23.1.0'
+    compile 'com.android.support:support-v4:23.1.1'
     compile 'net.iharder:base64:2.3.8'
 }

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
           android:versionCode="0"
           android:versionName="UPDATED-BY-BUILD"
           package="ch.acra.acra">
-    
+
     <!--
         Version API Name
         6.0     23  Marshmallow
@@ -39,4 +39,18 @@
         1.0     1
     -->
     <uses-sdk android:minSdkVersion="3" android:targetSdkVersion="23"/>
+
+    <application>
+        <activity
+            android:name="org.acra.CrashReportDialog"
+            android:theme="@android:style/Theme.Dialog"
+            android:launchMode="singleInstance"
+            android:excludeFromRecents="true"
+            android:finishOnTaskLaunch="true"/>
+
+        <service
+            android:name="org.acra.SenderService"
+            android:exported="false"
+            android:process=":acra" />
+    </application>
 </manifest>

--- a/src/main/java/org/acra/SendWorker.java
+++ b/src/main/java/org/acra/SendWorker.java
@@ -15,25 +15,24 @@
  */
 package org.acra;
 
-import static org.acra.ACRA.LOG_TAG;
+import android.content.Context;
+import org.acra.collector.CrashReportData;
+import org.acra.sender.ReportSender;
+import org.acra.sender.ReportSenderException;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import org.acra.collector.CrashReportData;
-import org.acra.sender.ReportSender;
-import org.acra.sender.ReportSenderException;
-
-import android.content.Context;
+import static org.acra.ACRA.LOG_TAG;
 
 /**
  * Checks and send reports on a separate Thread.
- * 
+ *
  * @author Kevin Gaudin
  */
-final class SendWorker extends Thread {
+final class SendWorker {
 
     private final Context context;
     private final boolean sendOnlySilentReports;
@@ -43,7 +42,7 @@ final class SendWorker extends Thread {
 
     /**
      * Creates a new {@link SendWorker} to try sending pending reports.
-     * 
+     *
      * @param context
      *            ApplicationContext in which the reports are being sent.
      * @param reportSenders
@@ -65,10 +64,9 @@ final class SendWorker extends Thread {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see java.lang.Thread#run()
      */
-    @Override
     public void run() {
         if (approvePendingReports) {
             approvePendingReports();
@@ -107,7 +105,7 @@ final class SendWorker extends Thread {
 
     /**
      * Send pending reports.
-     * 
+     *
      * @param context
      *            The application context.
      * @param sendOnlySilentReports
@@ -164,7 +162,7 @@ final class SendWorker extends Thread {
      * Sends the report with all configured ReportSenders. If at least one
      * sender completed its job, the report is considered as sent and will not
      * be sent again for failing senders.
-     * 
+     *
      * @param errorContent
      *            Crash data.
      * @throws ReportSenderException

--- a/src/main/java/org/acra/SenderService.java
+++ b/src/main/java/org/acra/SenderService.java
@@ -1,0 +1,39 @@
+package org.acra;
+
+import android.app.IntentService;
+import android.content.Intent;
+import org.acra.sender.ReportSender;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class SenderService extends IntentService {
+
+    public static final String EXTRA_ONLY_SEND_SILENT_REPORTS = "onlySendSilentReports";
+    public static final String EXTRA_APPROVE_REPORTS_FIRST = "approveReportsFirst";
+    public static final String EXTRA_REPORT_SENDERS = "reportSenders";
+
+    public SenderService() {
+        super("ACRA Report Sender");
+    }
+
+    @Override
+    protected void onHandleIntent(final Intent intent) {
+        final boolean onlySendSilentReports = intent.getBooleanExtra(EXTRA_ONLY_SEND_SILENT_REPORTS, false);
+        final boolean approveReportsFirst = intent.getBooleanExtra(EXTRA_APPROVE_REPORTS_FIRST, false);
+        final Serializable reportSenders = intent.getSerializableExtra(EXTRA_REPORT_SENDERS);
+
+        try {
+            //noinspection unchecked
+            final ArrayList<Class<? extends ReportSender>> senderClasses = (ArrayList<Class<? extends ReportSender>>) reportSenders;
+            final ArrayList<ReportSender> senderInstances = new ArrayList<ReportSender>();
+            for (final Class<? extends ReportSender> senderClass : senderClasses) {
+                senderInstances.add(senderClass.newInstance());
+            }
+
+            new SendWorker(this, senderInstances, onlySendSilentReports, approveReportsFirst).run();
+        } catch (Exception e) {
+            ACRA.log.e(ACRA.class.getSimpleName(), "", e);
+        }
+    }
+}


### PR DESCRIPTION
This is a basic implementation.

Possible improvements:
- Show notification while send task in progress (prevents from rare system-initiated process kill).
- Merge `SendService` and `SendWorker`.
- Self-stop `SendService` after delay.
- Subscribe to "Internet availabale" broadcast and start `SendService`.