### PR TITLE
Remove inet harder

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ ACRA v4.7
 - Support for Android M (6.0)
   - Using HtttpUrlConnection instead of Apache Http
   - Using com.android.support:support-v4 to provide support fro removed Notification methods.
+- Minimum Android version is Froyo (2.2). ACRA will disable itself for anything prior to that.  
 - Packaging as an AAR.
   In order to use com.android.support:support-v4 ACRA now needs to be packaged as an AAR instead of a JAR.
 - Removal of maxNumberOfRequestRetries config as HttpUrlConnection does not natively support retries on Socket timeout.

--- a/build.gradle
+++ b/build.gradle
@@ -26,5 +26,4 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:support-v4:23.1.0'
-    compile 'net.iharder:base64:2.3.8'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>ch.acra</groupId>
 	<artifactId>acra</artifactId>
 	<packaging>aar</packaging>
-	<version>4.7.1-RC.2-SNAPSHOT</version>
+	<version>4.7.0-RC.3-SNAPSHOT</version>
 
 	<name>Application Crash Report for Android</name>
 
@@ -85,13 +85,6 @@
 			<version>4.8.1</version>
 			<type>jar</type>
 			<scope>test</scope>
-		</dependency>
-
-		<!-- Base64 library -->
-		<dependency>
-			<groupId>net.iharder</groupId>
-			<artifactId>base64</artifactId>
-			<version>2.3.8</version>
 		</dependency>
 
         <dependency>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -38,5 +38,5 @@
         1.1     2
         1.0     1
     -->
-    <uses-sdk android:minSdkVersion="3" android:targetSdkVersion="23"/>
+    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="23"/>
 </manifest>

--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -15,9 +15,9 @@
  */
 package org.acra;
 
+import android.os.Build;
 import org.acra.annotation.ReportsCrashes;
 import org.acra.log.ACRALog;
-import org.acra.log.HollowLog;
 import org.acra.log.AndroidLogDelegate;
 
 import android.app.Application;
@@ -154,6 +154,11 @@ public class ACRA {
      */
     public static void init(Application app, ACRAConfiguration config, boolean checkReportsOnApplicationStart){
 
+        boolean supportedAndroidVersion = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO);
+        if (!supportedAndroidVersion){
+            log.w(LOG_TAG, "ACRA 4.7.0+ requires Froyo or greater. ACRA is disabled and will NOT catch crashes or send messages.");
+        }
+
         if (mApplication != null) {
             log.w(LOG_TAG, "ACRA#init called more than once. Won't do anything more.");
             return;
@@ -171,11 +176,10 @@ public class ACRA {
         try {
             checkCrashResources(config);
 
-            log.d(LOG_TAG, "ACRA is enabled for " + mApplication.getPackageName() + ", initializing...");
-
             // Initialize ErrorReporter with all required data
-            final boolean enableAcra = !shouldDisableACRA(prefs);
-            final ErrorReporter errorReporter = new ErrorReporter(mApplication, prefs, enableAcra);
+            final boolean enableAcra = supportedAndroidVersion && !shouldDisableACRA(prefs);
+            log.d(LOG_TAG, "ACRA is " + (enableAcra ? "enabled" : "disabled") + " for " + mApplication.getPackageName() + ", initializing...");
+            final ErrorReporter errorReporter = new ErrorReporter(mApplication, prefs, enableAcra, supportedAndroidVersion);
 
             // Append ReportSenders.
             errorReporter.setDefaultReportSenders();

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -82,6 +82,7 @@ import static org.acra.ReportField.IS_SILENT;
  */
 public class ErrorReporter implements Thread.UncaughtExceptionHandler {
 
+    private final boolean supportedAndroidVersion;
     private boolean enabled = false;
 
     private final Application mContext;
@@ -133,11 +134,12 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
      *            Whether this ErrorReporter should capture Exceptions and
      *            forward their reports.
      */
-    ErrorReporter(Application context, SharedPreferences prefs, boolean enabled) {
+    ErrorReporter(Application context, SharedPreferences prefs, boolean enabled, boolean supportedAndroidVersion) {
 
         this.mContext = context;
         this.prefs = prefs;
         this.enabled = enabled;
+        this.supportedAndroidVersion = supportedAndroidVersion;
 
         // Store the initial Configuration state.
         // This is expensive to gather, so only do so if we plan to report it.
@@ -510,8 +512,12 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
      *            forward them as crash reports.
      */
     public void setEnabled(boolean enabled) {
-        ACRA.log.i(LOG_TAG, "ACRA is " + (enabled ? "enabled" : "disabled") + " for " + mContext.getPackageName());
-        this.enabled = enabled;
+        if (!supportedAndroidVersion) {
+            ACRA.log.w(LOG_TAG, "ACRA 4.7.0+ requires Froyo or greater. ACRA is disabled and will NOT catch crashes or send messages.");
+        } else {
+            ACRA.log.i(LOG_TAG, "ACRA is " + (enabled ? "enabled" : "disabled") + " for " + mContext.getPackageName());
+            this.enabled = enabled;
+        }
     }
 
     /**

--- a/src/main/java/org/acra/util/HttpRequest.java
+++ b/src/main/java/org/acra/util/HttpRequest.java
@@ -5,7 +5,7 @@
  */
 package org.acra.util;
 
-import net.iharder.Base64;
+import android.util.Base64;
 import org.acra.ACRA;
 import org.acra.sender.HttpSender.Method;
 import org.acra.sender.HttpSender.Type;
@@ -89,7 +89,7 @@ public final class HttpRequest {
         // Set Credentials
         if ((login != null) && (password != null)) {
             final String credentials = login + ":" + password;
-            final String encoded = Base64.encodeBytes(credentials.getBytes("UTF-8"));
+            final String encoded = new String(Base64.encode(credentials.getBytes("UTF-8"), Base64.DEFAULT), "UTF-8");
             urlConnection.setRequestProperty("Authorization", "Basic " + encoded);
         }
 


### PR DESCRIPTION
Removing use of inet.harder library.
ACRA requires Froyo or greater. If no Froyo then ACRA disables itself.