### PR TITLE
Fix LogFileCollector to read logs from sub-directories

### DIFF
--- a/src/main/java/org/acra/collector/LogFileCollector.java
+++ b/src/main/java/org/acra/collector/LogFileCollector.java
@@ -74,7 +74,7 @@ class LogFileCollector {
 
     private static BufferedReader getReader(Context context, String fileName) {
         try {
-            if (fileName.contains("/")) {
+            if (fileName.startsWith("/")) {
                 return new BufferedReader(new InputStreamReader(new FileInputStream(fileName)), 1024);
             } else {
                 return new BufferedReader(new InputStreamReader(context.openFileInput(fileName)), 1024);


### PR DESCRIPTION
FileInputStream() should be used only when a pull path is given, the path which starts with "/". In other cases context.openFileInput() should be used. So log files can be placed in sub-directories of the main app package directory.