### PR TITLE
Make Dialog easier to extend

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     lintOptions {
         abortOnError false


### PR DESCRIPTION
I liked the default dialog, but I wanted to apply minimal changes to it. That is currently very hard. In my implementation (note: no logic changed) I have several Methods which can be overridden to modify just parts of the dialog:
- addViewToDialog can be used to add view to the start (call before buildCutomView) or end of the dialog (call after buildCustomView)
- getMainView, getCommentPrompt and getEmailPrompt allow to modify or replace specific parts of the dialog
- buildAndShowDialog can be used to e.g. prevent the creation of the dialog in certain situations
- getDialog for more modifications to the dialog (e.g third button)

These allow more modifications than I would need, but I thought it will help in the future if it is more flexible.