### PR TITLE
Base64 authorization String needs to be NO-WRAP

### DIFF
--- a/src/main/java/org/acra/util/HttpRequest.java
+++ b/src/main/java/org/acra/util/HttpRequest.java
@@ -89,7 +89,7 @@ public final class HttpRequest {
         // Set Credentials
         if ((login != null) && (password != null)) {
             final String credentials = login + ":" + password;
-            final String encoded = new String(Base64.encode(credentials.getBytes("UTF-8"), Base64.DEFAULT), "UTF-8");
+            final String encoded = new String(Base64.encode(credentials.getBytes("UTF-8"), Base64.NO_WRAP), "UTF-8");
             urlConnection.setRequestProperty("Authorization", "Basic " + encoded);
         }
 


### PR DESCRIPTION
As DEFAULT follows RFC 2045 which wraps every 76 chars (and at end of String).
This fixes #338 which was all about basic authentication, especially for long credentials.