### PR TITLE
Hide all ACRA debug log unless ACRA.DEV_LOGGING is switched on.

### DIFF
--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -45,7 +45,7 @@ import org.acra.prefs.SharedPreferencesFactory;
  */
 public class ACRA {
 
-    public static final boolean DEV_LOGGING = false; // Should be false for release.
+    public static boolean DEV_LOGGING = false; // Should be false for release.
 
     public static final String LOG_TAG = ACRA.class.getSimpleName();
     

--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -259,7 +259,7 @@ public class ACRA {
      */
     private static boolean isACRASenderServiceProcess(Application app) {
         final String processName = getCurrentProcessName(app);
-        log.i(LOG_TAG, "ACRA processName='" + processName + "'");
+        log.d(LOG_TAG, "ACRA processName='" + processName + "'");
         return (processName != null) && processName.endsWith(ACRA_PRIVATE_PROCESS_NAME);
     }
 

--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -166,7 +166,7 @@ public class ACRA {
 
         final boolean senderServiceProcess = isACRASenderServiceProcess(app);
         if (senderServiceProcess) {
-            log.i(LOG_TAG, "Not initialising ACRA to listen for uncaught Exceptions as this is the SendWorker process and we only send reports, we don't capture them to avoid infinite loops");
+            if (ACRA.DEV_LOGGING) log.d(LOG_TAG, "Not initialising ACRA to listen for uncaught Exceptions as this is the SendWorker process and we only send reports, we don't capture them to avoid infinite loops");
         }
 
         boolean supportedAndroidVersion = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO);
@@ -193,7 +193,6 @@ public class ACRA {
 
             // Check prefs to see if we have converted from legacy (pre 4.8.0) ACRA
             if (!prefs.getBoolean(PREF__LEGACY_ALREADY_CONVERTED_TO_4_8_0, false)) {
-                log.i(LOG_TAG, "Migrating unsent ACRA reports to new file locations");
                 // If not then move reports to approved/unapproved folders and mark as converted.
                 new ReportMigrator(app).migrate();
 
@@ -204,7 +203,7 @@ public class ACRA {
 
             // Initialize ErrorReporter with all required data
             final boolean enableAcra = supportedAndroidVersion && !shouldDisableACRA(prefs);
-            log.d(LOG_TAG, "ACRA is " + (enableAcra ? "enabled" : "disabled") + " for " + mApplication.getPackageName() + ", initializing...");
+            if (ACRA.DEV_LOGGING) log.d(LOG_TAG, "ACRA is " + (enableAcra ? "enabled" : "disabled") + " for " + mApplication.getPackageName() + ", initializing...");
             errorReporterSingleton = new ErrorReporter(mApplication, configProxy, prefs, enableAcra, supportedAndroidVersion, !senderServiceProcess);
 
             // Check for approved reports and send them (if enabled).
@@ -259,7 +258,7 @@ public class ACRA {
      */
     private static boolean isACRASenderServiceProcess(Application app) {
         final String processName = getCurrentProcessName(app);
-        log.d(LOG_TAG, "ACRA processName='" + processName + "'");
+        if (ACRA.DEV_LOGGING) log.d(LOG_TAG, "ACRA processName='" + processName + "'");
         return (processName != null) && processName.endsWith(ACRA_PRIVATE_PROCESS_NAME);
     }
 

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -245,7 +245,7 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
 
         try {
             ACRA.log.e(LOG_TAG, "ACRA caught a " + e.getClass().getSimpleName() + " for " + context.getPackageName(), e);
-            ACRA.log.d(LOG_TAG, "Building report");
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Building report");
 
             performDeprecatedReportPriming();
 
@@ -356,7 +356,7 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
         try {
             exceptionHandlerInitializer.initializeExceptionHandler(this);
         } catch (Exception exceptionInRunnable) {
-            ACRA.log.d(LOG_TAG, "Failed to initialize " + exceptionHandlerInitializer + " from #handleException");
+            ACRA.log.w(LOG_TAG, "Failed to initialize " + exceptionHandlerInitializer + " from #handleException");
         }
     }
 

--- a/src/main/java/org/acra/builder/LastActivityManager.java
+++ b/src/main/java/org/acra/builder/LastActivityManager.java
@@ -29,8 +29,7 @@ public final class LastActivityManager {
             ApplicationHelper.registerActivityLifecycleCallbacks(application, new ActivityLifecycleCallbacksCompat() {
                 @Override
                 public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-                    if (ACRA.DEV_LOGGING)
-                        ACRA.log.d(LOG_TAG, "onActivityCreated " + activity.getClass());
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityCreated " + activity.getClass());
                     if (!(activity instanceof BaseCrashReportDialog)) {
                         // Ignore CrashReportDialog because we want the last
                         // application Activity that was started so that we can explicitly kill it off.
@@ -40,38 +39,32 @@ public final class LastActivityManager {
 
                 @Override
                 public void onActivityStarted(Activity activity) {
-                    if (ACRA.DEV_LOGGING)
-                        ACRA.log.d(LOG_TAG, "onActivityStarted " + activity.getClass());
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityStarted " + activity.getClass());
                 }
 
                 @Override
                 public void onActivityResumed(Activity activity) {
-                    if (ACRA.DEV_LOGGING)
-                        ACRA.log.d(LOG_TAG, "onActivityResumed " + activity.getClass());
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityResumed " + activity.getClass());
                 }
 
                 @Override
                 public void onActivityPaused(Activity activity) {
-                    if (ACRA.DEV_LOGGING)
-                        ACRA.log.d(LOG_TAG, "onActivityPaused " + activity.getClass());
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityPaused " + activity.getClass());
                 }
 
                 @Override
                 public void onActivityStopped(Activity activity) {
-                    if (ACRA.DEV_LOGGING)
-                        ACRA.log.d(LOG_TAG, "onActivityStopped " + activity.getClass());
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityStopped " + activity.getClass());
                 }
 
                 @Override
                 public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-                    if (ACRA.DEV_LOGGING)
-                        ACRA.log.i(LOG_TAG, "onActivitySaveInstanceState " + activity.getClass());
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivitySaveInstanceState " + activity.getClass());
                 }
 
                 @Override
                 public void onActivityDestroyed(Activity activity) {
-                    if (ACRA.DEV_LOGGING)
-                        ACRA.log.i(LOG_TAG, "onActivityDestroyed " + activity.getClass());
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityDestroyed " + activity.getClass());
                 }
             });
         }

--- a/src/main/java/org/acra/builder/ReportExecutor.java
+++ b/src/main/java/org/acra/builder/ReportExecutor.java
@@ -115,7 +115,7 @@ public final class ReportExecutor {
     public void execute(final ReportBuilder reportBuilder) {
 
         if (!enabled) {
-            ACRA.log.d(LOG_TAG, "ACRA is disabled. Report not sent.");
+            ACRA.log.v(LOG_TAG, "ACRA is disabled. Report not sent.");
             return;
         }
 
@@ -190,7 +190,7 @@ public final class ReportExecutor {
             }
 
         } else if (reportingInteractionMode == ReportingInteractionMode.NOTIFICATION) {
-            ACRA.log.d(LOG_TAG, "Creating Notification.");
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Creating Notification.");
             createNotification(reportFile, reportBuilder);
         }
 
@@ -205,7 +205,7 @@ public final class ReportExecutor {
 
                 @Override
                 public void run() {
-                    ACRA.log.d(LOG_TAG, "Waiting for " + ACRAConstants.TOAST_WAIT_DURATION
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Waiting for " + ACRAConstants.TOAST_WAIT_DURATION
                             + " millis from " + sentToastTimeMillis.initialTimeMillis
                             + " currentMillis=" + System.currentTimeMillis());
                     while (sentToastTimeMillis.getElapsedTime() < ACRAConstants.TOAST_WAIT_DURATION) {
@@ -213,7 +213,7 @@ public final class ReportExecutor {
                             // Wait a bit to let the user read the toast
                             Thread.sleep(100);
                         } catch (InterruptedException e1) {
-                            ACRA.log.d(LOG_TAG, "Interrupted while waiting for Toast to end.", e1);
+                            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Interrupted while waiting for Toast to end.", e1);
                         }
                     }
                     toastWaitEnded = true;
@@ -229,27 +229,27 @@ public final class ReportExecutor {
             @Override
             public void run() {
                 // We have to wait for the toast display to be completed.
-                ACRA.log.d(LOG_TAG, "Waiting for Toast");
+                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Waiting for Toast");
                 while (!toastWaitEnded) {
                     try {
                         Thread.sleep(100);
                     } catch (InterruptedException e1) {
-                        ACRA.log.d(LOG_TAG, "Error : ", e1);
+                        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Interrupted waiting for Toast");
                     }
                 }
-                ACRA.log.d(LOG_TAG, "Finished waiting for Toast");
+                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Finished waiting for Toast");
 
                 if (showDirectDialog) {
                     // Create a new activity task with the confirmation dialog.
                     // This new task will be persisted on application restart
                     // right after its death.
-                    ACRA.log.d(LOG_TAG, "Creating CrashReportDialog for " + reportFile);
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Creating CrashReportDialog for " + reportFile);
                     final Intent dialogIntent = createCrashReportDialogIntent(reportFile, reportBuilder);
                     dialogIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(dialogIntent);
                 }
 
-                ACRA.log.d(LOG_TAG, "Wait for Toast + worker ended. Kill Application ? " + reportBuilder.isEndApplication());
+                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Wait for Toast + worker ended. Kill Application ? " + reportBuilder.isEndApplication());
 
                 if (reportBuilder.isEndApplication()) {
                     endApplication(reportBuilder.getUncaughtExceptionThread(), reportBuilder.getException());
@@ -272,7 +272,7 @@ public final class ReportExecutor {
         final boolean handlingUncaughtException = uncaughtExceptionThread != null;
         if (handlingUncaughtException && letDefaultHandlerEndApplication && (defaultExceptionHandler != null)) {
             // Let the system default handler do it's job and display the force close dialog.
-            ACRA.log.d(LOG_TAG, "Handing Exception on to default ExceptionHandler");
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Handing Exception on to default ExceptionHandler");
             defaultExceptionHandler.uncaughtException(uncaughtExceptionThread, th);
         } else {
             // If ACRA handles user notifications with a Toast or a Notification
@@ -284,9 +284,9 @@ public final class ReportExecutor {
             // it. Activity#finish (and maybe it's parent too).
             final Activity lastActivity = lastActivityManager.getLastActivity();
             if (lastActivity != null) {
-                ACRA.log.i(LOG_TAG, "Finishing the last Activity prior to killing the Process");
+                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Finishing the last Activity prior to killing the Process");
                 lastActivity.finish();
-                ACRA.log.i(LOG_TAG, "Finished " + lastActivity.getClass());
+                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Finished " + lastActivity.getClass());
                 lastActivityManager.clearLastActivity();
             }
 
@@ -328,7 +328,7 @@ public final class ReportExecutor {
         final CharSequence tickerText = context.getText(config.resNotifTickerText());
         final long when = System.currentTimeMillis();
 
-        ACRA.log.d(LOG_TAG, "Creating Notification for " + reportFile);
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Creating Notification for " + reportFile);
         final Intent crashReportDialogIntent = createCrashReportDialogIntent(reportFile, reportBuilder);
         final PendingIntent contentIntent = PendingIntent.getActivity(context, mNotificationCounter++, crashReportDialogIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
@@ -387,7 +387,7 @@ public final class ReportExecutor {
      */
     private void saveCrashReportFile(File file, CrashReportData crashData) {
         try {
-            ACRA.log.d(LOG_TAG, "Writing crash report file " + file);
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Writing crash report file " + file);
             final CrashReportPersister persister = new CrashReportPersister();
             persister.store(crashData, file);
         } catch (Exception e) {
@@ -403,7 +403,7 @@ public final class ReportExecutor {
      * @param reportBuilder     ReportBuilder containing the details of the crash.
      */
     private Intent createCrashReportDialogIntent(File reportFile, ReportBuilder reportBuilder) {
-        ACRA.log.d(LOG_TAG, "Creating DialogIntent for " + reportFile + " exception=" + reportBuilder.getException());
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Creating DialogIntent for " + reportFile + " exception=" + reportBuilder.getException());
         final Intent dialogIntent = new Intent(context, config.reportDialogClass());
         dialogIntent.putExtra(ACRAConstants.EXTRA_REPORT_FILE, reportFile);
         dialogIntent.putExtra(ACRAConstants.EXTRA_REPORT_EXCEPTION, reportBuilder.getException());

--- a/src/main/java/org/acra/builder/ReportExecutor.java
+++ b/src/main/java/org/acra/builder/ReportExecutor.java
@@ -89,7 +89,7 @@ public final class ReportExecutor {
 
     public void handReportToDefaultExceptionHandler(Thread t, Throwable e) {
         if (defaultExceptionHandler != null) {
-            ACRA.log.e(LOG_TAG, "ACRA is disabled for " + context.getPackageName()
+            ACRA.log.i(LOG_TAG, "ACRA is disabled for " + context.getPackageName()
                     + " - forwarding uncaught Exception on to default ExceptionHandler");
             defaultExceptionHandler.uncaughtException(t, e);
         } else {

--- a/src/main/java/org/acra/collector/CrashReportDataFactory.java
+++ b/src/main/java/org/acra/collector/CrashReportDataFactory.java
@@ -146,7 +146,7 @@ public final class CrashReportDataFactory {
             // Though, we can call logcat without any permission and still get traces related to our app.
             final boolean hasReadLogsPermission = pm.hasPermission(Manifest.permission.READ_LOGS) || (Compatibility.getAPILevel() >= Compatibility.VERSION_CODES.JELLY_BEAN);
             if (prefs.getBoolean(ACRA.PREF_ENABLE_SYSTEM_LOGS, true) && hasReadLogsPermission) {
-                ACRA.log.i(LOG_TAG, "READ_LOGS granted! ACRA can include LogCat and DropBox data.");
+                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "READ_LOGS granted! ACRA can include LogCat and DropBox data.");
                 final LogCatCollector logCatCollector = new LogCatCollector();
                 if (crashReportFields.contains(LOGCAT)) {
                     try {
@@ -177,7 +177,7 @@ public final class CrashReportDataFactory {
                     }
                 }
             } else {
-                ACRA.log.i(LOG_TAG, "READ_LOGS not allowed. ACRA will not include LogCat and DropBox data.");
+                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "READ_LOGS not allowed. ACRA will not include LogCat and DropBox data.");
             }
 
             try {

--- a/src/main/java/org/acra/collector/DropBoxCollector.java
+++ b/src/main/java/org/acra/collector/DropBoxCollector.java
@@ -15,17 +15,15 @@
  */
 package org.acra.collector;
 
-import java.lang.reflect.InvocationTargetException;
+import android.content.Context;
+import android.text.format.Time;
+import org.acra.ACRA;
+import org.acra.config.ACRAConfig;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import org.acra.ACRA;
-
-import android.content.Context;
-import android.text.format.Time;
-import org.acra.config.ACRAConfig;
 
 import static org.acra.ACRA.LOG_TAG;
 
@@ -117,18 +115,8 @@ final class DropBoxCollector {
             }
             return dropboxContent.toString();
 
-        } catch (SecurityException e) {
-            ACRA.log.i(LOG_TAG, "DropBoxManager not available.");
-        } catch (NoSuchMethodException e) {
-            ACRA.log.i(LOG_TAG, "DropBoxManager not available.");
-        } catch (IllegalArgumentException e) {
-            ACRA.log.i(LOG_TAG, "DropBoxManager not available.");
-        } catch (IllegalAccessException e) {
-            ACRA.log.i(LOG_TAG, "DropBoxManager not available.");
-        } catch (InvocationTargetException e) {
-            ACRA.log.i(LOG_TAG, "DropBoxManager not available.");
-        } catch (NoSuchFieldException e) {
-            ACRA.log.i(LOG_TAG, "DropBoxManager not available.");
+        } catch (Exception e) {
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "DropBoxManager not available.");
         }
 
         return NO_RESULT;

--- a/src/main/java/org/acra/collector/LogCatCollector.java
+++ b/src/main/java/org/acra/collector/LogCatCollector.java
@@ -100,7 +100,7 @@ class LogCatCollector {
             final Process process = Runtime.getRuntime().exec(commandLine.toArray(new String[commandLine.size()]));
             bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()), ACRAConstants.DEFAULT_BUFFER_SIZE_IN_BYTES);
 
-            ACRA.log.d(LOG_TAG, "Retrieving logcat output...");
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Retrieving logcat output...");
 
             // Dump stderr to null
             new Thread(new Runnable() {

--- a/src/main/java/org/acra/collector/SharedPreferencesCollector.java
+++ b/src/main/java/org/acra/collector/SharedPreferencesCollector.java
@@ -83,7 +83,7 @@ final class SharedPreferencesCollector {
             // Add all non-filtered preferences from that preference file.
             for (final String key : prefEntries.keySet()) {
                 if (filteredKey(key)) {
-                    ACRA.log.d(LOG_TAG, "Filtered out sharedPreference=" + sharedPrefId + "  key=" + key + " due to filtering rule");
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Filtered out sharedPreference=" + sharedPrefId + "  key=" + key + " due to filtering rule");
                 } else {
                     final Object prefValue = prefEntries.get(key);
                     result.append(sharedPrefId).append('.').append(key).append('=');

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -135,13 +135,13 @@ public class ACRAConfiguration implements ACRAConfig, Serializable {
 
         final ReportField[] fieldsList;
         if (customReportFields.length != 0) {
-            ACRA.log.d(LOG_TAG, "Using custom Report Fields");
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Using custom Report Fields");
             fieldsList = customReportFields;
         } else if (mailTo() == null || "".equals(mailTo())) {
-            ACRA.log.d(LOG_TAG, "Using default Report Fields");
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Using default Report Fields");
             fieldsList = ACRAConstants.DEFAULT_REPORT_FIELDS;
         } else {
-            ACRA.log.d(LOG_TAG, "Using default Mail Report Fields");
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Using default Mail Report Fields");
             fieldsList = ACRAConstants.DEFAULT_MAIL_REPORT_FIELDS;
         }
         return Arrays.asList(fieldsList);

--- a/src/main/java/org/acra/dialog/BaseCrashReportDialog.java
+++ b/src/main/java/org/acra/dialog/BaseCrashReportDialog.java
@@ -43,20 +43,20 @@ public abstract class BaseCrashReportDialog extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        ACRA.log.d(LOG_TAG, "CrashReportDialog extras=" + getIntent().getExtras());
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "CrashReportDialog extras=" + getIntent().getExtras());
 
         config = (ACRAConfig) getIntent().getSerializableExtra(ACRAConstants.EXTRA_REPORT_CONFIG);
 
         final boolean forceCancel = getIntent().getBooleanExtra(ACRAConstants.EXTRA_FORCE_CANCEL, false);
         if (forceCancel) {
-            ACRA.log.d(LOG_TAG, "Forced reports deletion.");
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Forced reports deletion.");
             cancelReports();
             finish();
             return;
         }
 
         reportFile = (File) getIntent().getSerializableExtra(ACRAConstants.EXTRA_REPORT_FILE);
-        ACRA.log.d(LOG_TAG, "Opening CrashReportDialog for " + reportFile);
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Opening CrashReportDialog for " + reportFile);
         if (reportFile == null) {
             finish();
         }
@@ -79,7 +79,7 @@ public abstract class BaseCrashReportDialog extends Activity {
     protected void sendCrash(String comment, String userEmail) {
         final CrashReportPersister persister = new CrashReportPersister();
         try {
-            ACRA.log.d(LOG_TAG, "Add user comment to " + reportFile);
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Add user comment to " + reportFile);
             final CrashReportData crashData = persister.load(reportFile);
             crashData.put(USER_COMMENT, comment == null ? "" : comment);
             crashData.put(USER_EMAIL, userEmail == null ? "" : userEmail);

--- a/src/main/java/org/acra/file/BulkReportDeleter.java
+++ b/src/main/java/org/acra/file/BulkReportDeleter.java
@@ -32,7 +32,7 @@ public final class BulkReportDeleter {
 
         for (int i = 0; i < files.length - nrToKeep; i++) {
             if (!files[i].delete()) {
-                ACRA.log.e(LOG_TAG, "Could not delete report : " + files[i]);
+                ACRA.log.w(LOG_TAG, "Could not delete report : " + files[i]);
             }
         }
     }

--- a/src/main/java/org/acra/legacy/ReportMigrator.java
+++ b/src/main/java/org/acra/legacy/ReportMigrator.java
@@ -26,6 +26,8 @@ public final class ReportMigrator {
     }
 
     public void migrate() {
+        ACRA.log.i(LOG_TAG, "Migrating unsent ACRA reports to new file locations");
+
         final File[] reportFiles = getCrashReportFiles();
 
         for (final File file : reportFiles) {
@@ -33,11 +35,11 @@ public final class ReportMigrator {
             final String fileName = file.getName();
             if (fileNameParser.isApproved(fileName)) {
                 if (file.renameTo(new File(reportLocator.getApprovedFolder(), fileName))) {
-                    ACRA.log.d(LOG_TAG, "Cold not migrate unsent ACRA crash report : " + fileName);
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Cold not migrate unsent ACRA crash report : " + fileName);
                 }
             } else {
                 if (file.renameTo(new File(reportLocator.getUnapprovedFolder(), fileName))) {
-                    ACRA.log.d(LOG_TAG, "Cold not migrate unsent ACRA crash report : " + fileName);
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Cold not migrate unsent ACRA crash report : " + fileName);
                 }
             }
         }
@@ -56,7 +58,7 @@ public final class ReportMigrator {
             return new File[0];
         }
 
-        ACRA.log.d(LOG_TAG, "Looking for error files in " + dir.getAbsolutePath());
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Looking for error files in " + dir.getAbsolutePath());
 
         // Filter for ".stacktrace" files
         final FilenameFilter filter = new FilenameFilter() {

--- a/src/main/java/org/acra/sender/DefaultReportSenderFactory.java
+++ b/src/main/java/org/acra/sender/DefaultReportSenderFactory.java
@@ -37,7 +37,7 @@ public final class DefaultReportSenderFactory implements ReportSenderFactory {
             return new NullSender();
         } else if (config.formUri() != null && !"".equals(config.formUri())) {
             // If formUri is set, instantiate a sender for a generic HTTP POST form with default mapping.
-            ACRA.log.i(LOG_TAG, context.getPackageName() + " reports will be sent by Http.");
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, context.getPackageName() + " reports will be sent by Http.");
             return new HttpSenderFactory().create(context, config);
         } else {
             return new NullSender();

--- a/src/main/java/org/acra/sender/HttpSender.java
+++ b/src/main/java/org/acra/sender/HttpSender.java
@@ -186,7 +186,7 @@ public class HttpSender implements ReportSender {
 
         try {
             URL reportUrl = mFormUri == null ? new URL(config.formUri()) : new URL(mFormUri.toString());
-            ACRA.log.d(LOG_TAG, "Connect to " + reportUrl.toString());
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Connect to " + reportUrl.toString());
 
             final String login = mUsername != null ? mUsername : isNull(config.formUriBasicAuthLogin()) ? null : config.formUriBasicAuthLogin();
             final String password = mPassword != null ? mPassword : isNull(config.formUriBasicAuthPassword()) ? null : config.formUriBasicAuthPassword();

--- a/src/main/java/org/acra/sender/ReportDistributor.java
+++ b/src/main/java/org/acra/sender/ReportDistributor.java
@@ -96,9 +96,9 @@ final class ReportDistributor {
             String failedSender = null;
             for (ReportSender sender : reportSenders) {
                 try {
-                    ACRA.log.d(LOG_TAG, "Sending report using " + sender.getClass().getName());
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Sending report using " + sender.getClass().getName());
                     sender.send(context, errorContent);
-                    ACRA.log.d(LOG_TAG, "Sent report using " + sender.getClass().getName());
+                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Sent report using " + sender.getClass().getName());
 
                     // If at least one sender worked, don't re-send the report later.
                     sentAtLeastOnce = true;

--- a/src/main/java/org/acra/sender/SenderService.java
+++ b/src/main/java/org/acra/sender/SenderService.java
@@ -39,7 +39,7 @@ public class SenderService extends IntentService {
 
         final ACRAConfig config = (ACRAConfig) intent.getSerializableExtra(EXTRA_ACRA_CONFIG);
 
-        ACRA.log.v(LOG_TAG, "About to start sending reports from SenderService");
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "About to start sending reports from SenderService");
         try {
             final List<ReportSender> senderInstances = getSenderInstances(config, senderFactoryClasses);
 
@@ -71,7 +71,7 @@ public class SenderService extends IntentService {
             ACRA.log.e(LOG_TAG, "", e);
         }
 
-        ACRA.log.d(LOG_TAG, "Finished sending reports from SenderService");
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Finished sending reports from SenderService");
     }
 
     private List<ReportSender> getSenderInstances(ACRAConfig config, Class<? extends ReportSenderFactory>[] factoryClasses) {
@@ -94,7 +94,7 @@ public class SenderService extends IntentService {
      * Flag all pending reports as "approved" by the user. These reports can be sent.
      */
     private void markReportsAsApproved() {
-        ACRA.log.d(LOG_TAG, "Mark all pending reports as approved.");
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Mark all pending reports as approved.");
 
         for (File report : locator.getUnapprovedReports()) {
             final File approvedReport = new File(locator.getApprovedFolder(), report.getName());

--- a/src/main/java/org/acra/sender/SenderService.java
+++ b/src/main/java/org/acra/sender/SenderService.java
@@ -68,7 +68,7 @@ public class SenderService extends IntentService {
                 reportDistributor.distribute(report);
             }
         } catch (Exception e) {
-            ACRA.log.e(ACRA.class.getSimpleName(), "", e);
+            ACRA.log.e(LOG_TAG, "", e);
         }
 
         ACRA.log.d(LOG_TAG, "Finished sending reports from SenderService");
@@ -99,7 +99,7 @@ public class SenderService extends IntentService {
         for (File report : locator.getUnapprovedReports()) {
             final File approvedReport = new File(locator.getApprovedFolder(), report.getName());
             if (!report.renameTo(approvedReport)) {
-                ACRA.log.e(LOG_TAG, "Could not rename approved report from " + report + " to " + approvedReport);
+                ACRA.log.w(LOG_TAG, "Could not rename approved report from " + report + " to " + approvedReport);
             }
         }
     }

--- a/src/main/java/org/acra/sender/SenderServiceStarter.java
+++ b/src/main/java/org/acra/sender/SenderServiceStarter.java
@@ -27,7 +27,7 @@ public class SenderServiceStarter {
      * @param approveReportsFirst   If true then approve unapproved reports first.
      */
     public void startService(boolean onlySendSilentReports, boolean approveReportsFirst) {
-        ACRA.log.v(LOG_TAG, "About to start SenderService");
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "About to start SenderService");
         final Intent intent = new Intent(context, SenderService.class);
         intent.putExtra(SenderService.EXTRA_ONLY_SEND_SILENT_REPORTS, onlySendSilentReports);
         intent.putExtra(SenderService.EXTRA_APPROVE_REPORTS_FIRST, approveReportsFirst);

--- a/src/main/java/org/acra/util/HttpRequest.java
+++ b/src/main/java/org/acra/util/HttpRequest.java
@@ -130,28 +130,26 @@ public final class HttpRequest {
         outputStream.flush();
         outputStream.close();
 
-        ACRA.log.d(LOG_TAG,"Sending request to " + url);
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG,"Sending request to " + url);
         if(ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Http " + method.name() + " content : ");
         if(ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, content);
 
         final int responseCode = urlConnection.getResponseCode();
-        ACRA.log.d(LOG_TAG,"Request response : " + responseCode + " : " + urlConnection.getResponseMessage());
+        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG,"Request response : " + responseCode + " : " + urlConnection.getResponseMessage());
         if ((responseCode >= 200) && (responseCode < 300)) {
             // All is good
-            ACRA.log.d(LOG_TAG,"Request received by server");
+            ACRA.log.i(LOG_TAG,"Request received by server");
         } else if (responseCode == 403) {
             // 403 is an explicit data validation refusal from the server. The request must not be repeated. Discard it.
-            ACRA.log.d(LOG_TAG, "Data validation error on server - request will be discarded");
+            ACRA.log.w(LOG_TAG, "Data validation error on server - request will be discarded");
         } else if (responseCode == 409) {
             // 409 means that the report has been received already. So we can discard it.
-            ACRA.log.d(LOG_TAG, "Server has already received this post - request will be discarded");
+            ACRA.log.w(LOG_TAG, "Server has already received this post - request will be discarded");
         } else if ((responseCode >= 400) && (responseCode < 600)) {
-            if (ACRA.DEV_LOGGING) {
-                ACRA.log.d(LOG_TAG, "Could not send ACRA Post");
-            }
+            ACRA.log.w(LOG_TAG, "Could not send ACRA Post responseCode=" + responseCode + " message=" + urlConnection.getResponseMessage());
             throw new IOException("Host returned error code " + responseCode);
         } else {
-            ACRA.log.w(LOG_TAG, "Could not send ACRA Post - request will be discarded");
+            ACRA.log.w(LOG_TAG, "Could not send ACRA Post - request will be discarded responseCode=" + responseCode + " message=" + urlConnection.getResponseMessage());
         }
 
         urlConnection.disconnect();

--- a/src/main/java/org/acra/util/JSONReportBuilder.java
+++ b/src/main/java/org/acra/util/JSONReportBuilder.java
@@ -84,7 +84,7 @@ public class JSONReportBuilder {
                             addJSONFromProperty(subObject, line);
                         }
                     } catch (IOException e) {
-                        ACRA.log.e(LOG_TAG, "Error while converting " + key.name() + " to JSON.", e);
+                        ACRA.log.w(LOG_TAG, "Error while converting " + key.name() + " to JSON.", e);
                     }
                     jsonReport.accumulate(key.name(), subObject);
                 } else {
@@ -215,7 +215,7 @@ public class JSONReportBuilder {
                     }
 
                     if (intermediate == null) {
-                        ACRA.log.e(LOG_TAG, "Unknown json subtree type, see issue #186");
+                        ACRA.log.w(LOG_TAG, "Unknown json subtree type, see issue #186");
                         // We should never get here, but if we do, drop this value to still send the report
                         return;
                     }

--- a/src/main/java/org/acra/util/PackageManagerWrapper.java
+++ b/src/main/java/org/acra/util/PackageManagerWrapper.java
@@ -63,7 +63,7 @@ public final class PackageManagerWrapper {
         try {
             return pm.getPackageInfo(context.getPackageName(), 0);
         } catch (PackageManager.NameNotFoundException e) {
-            ACRA.log.v(LOG_TAG, "Failed to find PackageInfo for current App : " + context.getPackageName());
+            ACRA.log.w(LOG_TAG, "Failed to find PackageInfo for current App : " + context.getPackageName());
             return null;
         } catch (RuntimeException e) {
             // To catch RuntimeException("Package manager has died") that can occur on some version of Android,

--- a/src/main/java/org/acra/util/ToastSender.java
+++ b/src/main/java/org/acra/util/ToastSender.java
@@ -26,7 +26,7 @@ public final class ToastSender {
         try {
             Toast.makeText(context, toastResourceId, toastLength).show();
         } catch (RuntimeException e) {
-            ACRA.log.e(LOG_TAG, "Could not send crash Toast", e);
+            ACRA.log.w(LOG_TAG, "Could not send crash Toast", e);
         }
     }
 }


### PR DESCRIPTION
All debug messages are prefix by `if (ACRA.DEV_LOGGING)`, so if you want ACRA debug configure `ACRA.DEV_LOGGING` on first.