### PR TITLE
Followup

### DIFF
--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -185,7 +185,8 @@ public final class ACRA {
             return;
         }
         mApplication = app;
-        
+
+        //noinspection ConstantConditions
         if (config == null) {
             log.e(LOG_TAG, "ACRA#init called but no ACRAConfiguration provided");
             return;
@@ -340,7 +341,7 @@ public final class ACRA {
     @NonNull
     @SuppressWarnings( "unused" )
     public static ACRAConfiguration getConfig() {
-        if (mApplication == null) {
+        if (configProxy == null) {
             throw new IllegalStateException("Cannot call ACRA.getConfig() before ACRA.init().");
         }
         return configProxy;

--- a/src/main/java/org/acra/builder/ReportPrimer.java
+++ b/src/main/java/org/acra/builder/ReportPrimer.java
@@ -8,7 +8,7 @@ import java.util.Map;
  * Primes a {@link ReportBuilder} with any extra data to record for the current crash report.
  *
  * ReportPrimer is configured declaratively via {@link org.acra.annotation.ReportsCrashes#reportPrimerClass()}.
- * The ReportPrimer class MUST have a no arg constructor and is created when ACRA is intialised.
+ * The ReportPrimer class MUST have a no arg constructor and is created when ACRA is initialised.
  *
  * Created by William on 9 Jan 2016.
  * @since 4.8.0
@@ -23,7 +23,7 @@ public interface ReportPrimer {
      *
      * Note that this method will only be called if ACRA is currently enabled.
      *
-     * @param context   Application context from whcih to retrieve resources.
+     * @param context   Application context from which to retrieve resources.
      * @param builder   Full configured {@link ReportBuilder} for the current crash report.
      */
     void primeReport(Context context, ReportBuilder builder);

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -190,6 +190,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @SuppressWarnings( "unused" )
     public ACRAConfiguration(){
+        //TODO this will always throw a NPE! Intended?
         this(null);
     }
 
@@ -254,7 +255,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setAdditionalDropboxTags(String[] additionalDropboxTags) {
+    public ACRAConfiguration setAdditionalDropboxTags(@NonNull String[] additionalDropboxTags) {
         this.additionalDropBoxTags = copyArray(additionalDropboxTags);
         return this;
     }
@@ -266,7 +267,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setAdditionalSharedPreferences(String[] additionalSharedPreferences) {
+    public ACRAConfiguration setAdditionalSharedPreferences(@NonNull String[] additionalSharedPreferences) {
         this.additionalSharedPreferences = copyArray(additionalSharedPreferences);
         return this;
     }
@@ -290,7 +291,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setCustomReportContent(ReportField[] customReportContent) {
+    public ACRAConfiguration setCustomReportContent(@NonNull ReportField[] customReportContent) {
         this.customReportContent = copyArray(customReportContent);
         return this;
     }
@@ -677,7 +678,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setSocketTimeout(Integer socketTimeout) {
+    public ACRAConfiguration setSocketTimeout(@NonNull Integer socketTimeout) {
         this.socketTimeout = socketTimeout;
         return this;
     }
@@ -693,7 +694,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setLogcatFilterByPid(Boolean filterByPid) {
+    public ACRAConfiguration setLogcatFilterByPid(@NonNull Boolean filterByPid) {
         logcatFilterByPid = filterByPid;
         return this;
     }
@@ -708,7 +709,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setSendReportsInDevMode(Boolean sendReportsInDevMode) {
+    public ACRAConfiguration setSendReportsInDevMode(@NonNull Boolean sendReportsInDevMode) {
         this.sendReportsInDevMode = sendReportsInDevMode;
         return this;
     }
@@ -724,7 +725,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setSendReportsAtShutdown(Boolean sendReportsAtShutdown) {
+    public ACRAConfiguration setSendReportsAtShutdown(@NonNull Boolean sendReportsAtShutdown) {
         this.sendReportsAtShutdown = sendReportsAtShutdown;
         return this;
     }
@@ -741,7 +742,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setExcludeMatchingSharedPreferencesKeys(String[] excludeMatchingSharedPreferencesKeys) {
+    public ACRAConfiguration setExcludeMatchingSharedPreferencesKeys(@NonNull String[] excludeMatchingSharedPreferencesKeys) {
         this.excludeMatchingSharedPreferencesKeys = copyArray(excludeMatchingSharedPreferencesKeys);
         return this;
     }
@@ -757,7 +758,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setExcludeMatchingSettingsKeys(String[] excludeMatchingSettingsKeys) {
+    public ACRAConfiguration setExcludeMatchingSettingsKeys(@NonNull String[] excludeMatchingSettingsKeys) {
         this.excludeMatchingSettingsKeys = copyArray(excludeMatchingSettingsKeys);
         return this;
     }
@@ -836,7 +837,7 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @SuppressWarnings("unused")
-    public void setReportSenderFactoryClasses(Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses) {
+    public void setReportSenderFactoryClasses(@NonNull Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses) {
         this.reportSenderFactoryClasses = copyArray(reportSenderFactoryClasses);
     }
 
@@ -1118,23 +1119,23 @@ public final class ACRAConfiguration implements Serializable {
     public void checkCrashResources() throws ACRAConfigurationException {
         switch (mode()) {
             case TOAST:
-                if (resToastText() == 0) {
+                if (resToastText() == ACRAConstants.DEFAULT_RES_VALUE) {
                     throw new ACRAConfigurationException(
                             "TOAST mode: you have to define the resToastText parameter in your application @ReportsCrashes() annotation.");
                 }
                 break;
             case NOTIFICATION:
-                if (resNotifTickerText() == 0 || resNotifTitle() == 0 || resNotifText() == 0) {
+                if (resNotifTickerText() == ACRAConstants.DEFAULT_RES_VALUE || resNotifTitle() == ACRAConstants.DEFAULT_RES_VALUE || resNotifText() == ACRAConstants.DEFAULT_RES_VALUE) {
                     throw new ACRAConfigurationException(
                             "NOTIFICATION mode: you have to define at least the resNotifTickerText, resNotifTitle, resNotifText parameters in your application @ReportsCrashes() annotation.");
                 }
-                if (CrashReportDialog.class.equals(reportDialogClass()) && resDialogText() == 0) {
+                if (CrashReportDialog.class.equals(reportDialogClass()) && resDialogText() == ACRAConstants.DEFAULT_RES_VALUE) {
                     throw new ACRAConfigurationException(
                             "NOTIFICATION mode: using the (default) CrashReportDialog requires you have to define the resDialogText parameter in your application @ReportsCrashes() annotation.");
                 }
                 break;
             case DIALOG:
-                if (CrashReportDialog.class.equals(reportDialogClass()) && resDialogText() == 0) {
+                if (CrashReportDialog.class.equals(reportDialogClass()) && resDialogText() == ACRAConstants.DEFAULT_RES_VALUE) {
                     throw new ACRAConfigurationException(
                             "DIALOG mode: using the (default) CrashReportDialog requires you to define the resDialogText parameter in your application @ReportsCrashes() annotation.");
                 }
@@ -1144,6 +1145,7 @@ public final class ACRAConfiguration implements Serializable {
         }
     }
 
+    @NonNull
     private static <T> T[] copyArray(@NonNull T[] source) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
             return Arrays.copyOf(source, source.length);

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -61,18 +61,19 @@ public final class ACRAConfiguration implements Serializable {
     private final Class<? extends Annotation> annotationType;
 
     // TODO Make all of these attributes final in ACRA 4.9 or 5.0
+    // consider using immutable Collections for Arrays and Collections, so this can be truly final
     private String[] additionalDropBoxTags;
     private String[] additionalSharedPreferences;
-    private Integer connectionTimeout;
+    private int connectionTimeout;
     private ReportField[] customReportContent;
-    private Boolean deleteUnapprovedReportsOnApplicationStart;
-    private Boolean deleteOldUnsentReportsOnApplicationStart;
-    private Integer dropboxCollectionMinutes;
-    private Boolean forceCloseDialogAfterToast;
+    private boolean deleteUnapprovedReportsOnApplicationStart;
+    private boolean deleteOldUnsentReportsOnApplicationStart;
+    private int dropboxCollectionMinutes;
+    private boolean forceCloseDialogAfterToast;
     private String formUri;
     private String formUriBasicAuthLogin;
     private String formUriBasicAuthPassword;
-    private Boolean includeDropBoxSystemTags;
+    private boolean includeDropBoxSystemTags;
 
     private String[] logcatArguments;
     private String mailTo;
@@ -81,44 +82,44 @@ public final class ACRAConfiguration implements Serializable {
     private Class<? extends ReportPrimer> reportPrimerClass;
 
     @StringRes
-    private Integer resDialogPositiveButtonText;
+    private int resDialogPositiveButtonText;
     @StringRes
-    private Integer resDialogNegativeButtonText;
+    private int resDialogNegativeButtonText;
     @StringRes
-    private Integer resDialogCommentPrompt;
+    private int resDialogCommentPrompt;
     @StringRes
-    private Integer resDialogEmailPrompt;
+    private int resDialogEmailPrompt;
     @DrawableRes
-    private Integer resDialogIcon;
+    private int resDialogIcon;
     @StringRes
-    private Integer resDialogOkToast;
+    private int resDialogOkToast;
     @StringRes
-    private Integer resDialogText;
+    private int resDialogText;
     @StringRes
-    private Integer resDialogTitle;
+    private int resDialogTitle;
     @DrawableRes
-    private Integer resNotifIcon;
+    private int resNotifIcon;
     @StringRes
-    private Integer resNotifText;
+    private int resNotifText;
     @StringRes
-    private Integer resNotifTickerText;
+    private int resNotifTickerText;
     @StringRes
-    private Integer resNotifTitle;
+    private int resNotifTitle;
     @StringRes
-    private Integer resToastText;
-    private Integer sharedPreferencesMode;
+    private int resToastText;
+    private int sharedPreferencesMode;
     private String sharedPreferencesName;
-    private Integer socketTimeout;
-    private Boolean logcatFilterByPid;
-    private Boolean sendReportsInDevMode;
-    private Boolean sendReportsAtShutdown;
+    private int socketTimeout;
+    private boolean logcatFilterByPid;
+    private boolean sendReportsInDevMode;
+    private boolean sendReportsAtShutdown;
 
     private String[] excludeMatchingSharedPreferencesKeys;
     private String[] excludeMatchingSettingsKeys;
     @Nullable
     private Class buildConfigClass;
     private String applicationLogFile;
-    private Integer applicationLogFileLines;
+    private int applicationLogFileLines;
 
     private Method httpMethod;
     private Type reportType;
@@ -279,7 +280,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public ACRAConfiguration setConnectionTimeout(@NonNull Integer connectionTimeout) {
+    public ACRAConfiguration setConnectionTimeout(int connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
         return this;
     }
@@ -303,7 +304,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public ACRAConfiguration setDeleteUnapprovedReportsOnApplicationStart(@NonNull Boolean deleteUnapprovedReportsOnApplicationStart) {
+    public ACRAConfiguration setDeleteUnapprovedReportsOnApplicationStart(boolean deleteUnapprovedReportsOnApplicationStart) {
         this.deleteUnapprovedReportsOnApplicationStart = deleteUnapprovedReportsOnApplicationStart;
         return this;
     }
@@ -315,7 +316,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public ACRAConfiguration setDeleteOldUnsentReportsOnApplicationStart(@NonNull Boolean deleteOldUnsentReportsOnApplicationStart) {
+    public ACRAConfiguration setDeleteOldUnsentReportsOnApplicationStart(boolean deleteOldUnsentReportsOnApplicationStart) {
         this.deleteOldUnsentReportsOnApplicationStart = deleteOldUnsentReportsOnApplicationStart;
         return this;
     }
@@ -327,7 +328,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public ACRAConfiguration setDropboxCollectionMinutes(@NonNull Integer dropboxCollectionMinutes) {
+    public ACRAConfiguration setDropboxCollectionMinutes(int dropboxCollectionMinutes) {
         this.dropboxCollectionMinutes = dropboxCollectionMinutes;
         return this;
     }
@@ -339,7 +340,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public ACRAConfiguration setForceCloseDialogAfterToast(@NonNull Boolean forceCloseDialogAfterToast) {
+    public ACRAConfiguration setForceCloseDialogAfterToast(boolean forceCloseDialogAfterToast) {
         this.forceCloseDialogAfterToast = forceCloseDialogAfterToast;
         return this;
     }
@@ -389,7 +390,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public ACRAConfiguration setIncludeDropboxSystemTags(@NonNull Boolean includeDropboxSystemTags) {
+    public ACRAConfiguration setIncludeDropboxSystemTags(boolean includeDropboxSystemTags) {
         this.includeDropBoxSystemTags = includeDropboxSystemTags;
         return this;
     }
@@ -653,7 +654,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public ACRAConfiguration setSharedPreferenceMode(@NonNull Integer sharedPreferenceMode) {
+    public ACRAConfiguration setSharedPreferenceMode(int sharedPreferenceMode) {
         this.sharedPreferencesMode = sharedPreferenceMode;
         return this;
     }
@@ -678,7 +679,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setSocketTimeout(@NonNull Integer socketTimeout) {
+    public ACRAConfiguration setSocketTimeout(int socketTimeout) {
         this.socketTimeout = socketTimeout;
         return this;
     }
@@ -694,7 +695,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setLogcatFilterByPid(@NonNull Boolean filterByPid) {
+    public ACRAConfiguration setLogcatFilterByPid(boolean filterByPid) {
         logcatFilterByPid = filterByPid;
         return this;
     }
@@ -709,7 +710,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setSendReportsInDevMode(@NonNull Boolean sendReportsInDevMode) {
+    public ACRAConfiguration setSendReportsInDevMode(boolean sendReportsInDevMode) {
         this.sendReportsInDevMode = sendReportsInDevMode;
         return this;
     }
@@ -725,7 +726,7 @@ public final class ACRAConfiguration implements Serializable {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ACRAConfiguration setSendReportsAtShutdown(@NonNull Boolean sendReportsAtShutdown) {
+    public ACRAConfiguration setSendReportsAtShutdown(boolean sendReportsAtShutdown) {
         this.sendReportsAtShutdown = sendReportsAtShutdown;
         return this;
     }

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -186,15 +186,6 @@ public final class ACRAConfiguration implements Serializable {
         keyStoreFactory = builder.keyStoreFactory();
     }
 
-    /**
-     * Empty constructor which sets no defaults.
-     */
-    @SuppressWarnings( "unused" )
-    public ACRAConfiguration(){
-        //TODO this will always throw a NPE! Intended?
-        this(null);
-    }
-
 
     /**
      * Set custom HTTP headers to be sent by the provided {@link HttpSender}.

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -223,7 +223,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setConnectionTimeout(@NonNull Integer connectionTimeout) {
+    public ConfigurationBuilder setConnectionTimeout(int connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
         return this;
     }
@@ -246,7 +246,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setDeleteUnapprovedReportsOnApplicationStart(@NonNull Boolean deleteUnapprovedReportsOnApplicationStart) {
+    public ConfigurationBuilder setDeleteUnapprovedReportsOnApplicationStart(boolean deleteUnapprovedReportsOnApplicationStart) {
         this.deleteUnapprovedReportsOnApplicationStart = deleteUnapprovedReportsOnApplicationStart;
         return this;
     }
@@ -257,7 +257,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setDeleteOldUnsentReportsOnApplicationStart(@NonNull Boolean deleteOldUnsentReportsOnApplicationStart) {
+    public ConfigurationBuilder setDeleteOldUnsentReportsOnApplicationStart(boolean deleteOldUnsentReportsOnApplicationStart) {
         this.deleteOldUnsentReportsOnApplicationStart = deleteOldUnsentReportsOnApplicationStart;
         return this;
     }
@@ -269,7 +269,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setDropboxCollectionMinutes(@NonNull Integer dropboxCollectionMinutes) {
+    public ConfigurationBuilder setDropboxCollectionMinutes(int dropboxCollectionMinutes) {
         this.dropboxCollectionMinutes = dropboxCollectionMinutes;
         return this;
     }
@@ -281,7 +281,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setForceCloseDialogAfterToast(@NonNull Boolean forceCloseDialogAfterToast) {
+    public ConfigurationBuilder setForceCloseDialogAfterToast(boolean forceCloseDialogAfterToast) {
         this.forceCloseDialogAfterToast = forceCloseDialogAfterToast;
         return this;
     }
@@ -330,7 +330,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setIncludeDropboxSystemTags(@NonNull Boolean includeDropboxSystemTags) {
+    public ConfigurationBuilder setIncludeDropboxSystemTags(boolean includeDropboxSystemTags) {
         this.includeDropBoxSystemTags = includeDropboxSystemTags;
         return this;
     }
@@ -594,7 +594,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setSharedPreferenceMode(@NonNull Integer sharedPreferenceMode) {
+    public ConfigurationBuilder setSharedPreferenceMode(int sharedPreferenceMode) {
         this.sharedPreferencesMode = sharedPreferenceMode;
         return this;
     }
@@ -618,7 +618,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setSocketTimeout(@NonNull Integer socketTimeout) {
+    public ConfigurationBuilder setSocketTimeout(int socketTimeout) {
         this.socketTimeout = socketTimeout;
         return this;
     }
@@ -632,7 +632,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setLogcatFilterByPid(@NonNull Boolean filterByPid) {
+    public ConfigurationBuilder setLogcatFilterByPid(boolean filterByPid) {
         logcatFilterByPid = filterByPid;
         return this;
     }
@@ -646,7 +646,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setSendReportsInDevMode(@NonNull Boolean sendReportsInDevMode) {
+    public ConfigurationBuilder setSendReportsInDevMode(boolean sendReportsInDevMode) {
         this.sendReportsInDevMode = sendReportsInDevMode;
         return this;
     }
@@ -661,7 +661,7 @@ public final class ConfigurationBuilder {
      */
     @NonNull
     @SuppressWarnings( "unused" )
-    public ConfigurationBuilder setSendReportsAtShutdown(@NonNull Boolean sendReportsAtShutdown) {
+    public ConfigurationBuilder setSendReportsAtShutdown(boolean sendReportsAtShutdown) {
         this.sendReportsAtShutdown = sendReportsAtShutdown;
         return this;
     }

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -360,7 +360,6 @@ public final class ConfigurationBuilder {
         return this;
     }
 
-    //why two methods with the same functionality?? (setMode, setReportingInteractionMode)
     /**
      * Change the current {@link ReportingInteractionMode}.
      * 

--- a/src/main/java/org/acra/sender/EmailIntentSender.java
+++ b/src/main/java/org/acra/sender/EmailIntentSender.java
@@ -35,19 +35,16 @@ import org.acra.config.ACRAConfiguration;
  */
 public class EmailIntentSender implements ReportSender {
 
-    private final Context mContext;
     private final ACRAConfiguration config;
 
-    //TODO why not use context passed in #send?
-    public EmailIntentSender(@NonNull Context ctx, @NonNull ACRAConfiguration config) {
-        mContext = ctx;
+    public EmailIntentSender(@NonNull ACRAConfiguration config) {
         this.config = config;
     }
 
     @Override
     public void send(@NonNull Context context, @NonNull CrashReportData errorContent) throws ReportSenderException {
 
-        final String subject = mContext.getPackageName() + " Crash Report";
+        final String subject = context.getPackageName() + " Crash Report";
         final String body = buildBody(errorContent);
 
         final Intent emailIntent = new Intent(android.content.Intent.ACTION_SENDTO);
@@ -55,7 +52,7 @@ public class EmailIntentSender implements ReportSender {
         emailIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         emailIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, subject);
         emailIntent.putExtra(android.content.Intent.EXTRA_TEXT, body);
-        mContext.startActivity(emailIntent);
+        context.startActivity(emailIntent);
     }
 
     private String buildBody(@NonNull CrashReportData errorContent) {

--- a/src/main/java/org/acra/sender/EmailIntentSenderFactory.java
+++ b/src/main/java/org/acra/sender/EmailIntentSenderFactory.java
@@ -13,6 +13,6 @@ public final class EmailIntentSenderFactory implements ReportSenderFactory {
     @NonNull
     @Override
     public ReportSender create(@NonNull Context context, @NonNull ACRAConfiguration config) {
-        return new EmailIntentSender(context, config);
+        return new EmailIntentSender(config);
     }
 }

--- a/src/main/java/org/acra/sender/SenderService.java
+++ b/src/main/java/org/acra/sender/SenderService.java
@@ -79,7 +79,6 @@ public class SenderService extends IntentService {
     private List<ReportSender> getSenderInstances(@NonNull ACRAConfiguration config, @NonNull List<Class<? extends ReportSenderFactory>> factoryClasses) {
         final List<ReportSender> reportSenders = new ArrayList<ReportSender>();
         for (final Class<? extends ReportSenderFactory> factoryClass : factoryClasses) {
-            //noinspection TryWithIdenticalCatches
             try {
                 final ReportSenderFactory factory = factoryClass.newInstance();
                 final ReportSender sender = factory.create(this.getApplication(), config);

--- a/src/main/java/org/acra/util/HttpRequest.java
+++ b/src/main/java/org/acra/util/HttpRequest.java
@@ -33,6 +33,7 @@ import static org.acra.ACRA.LOG_TAG;
 
 public final class HttpRequest {
 
+    private static final String UTF8 = "UTF-8";
     private static final int HTTP_SUCCESS = 200;
     private static final int HTTP_REDIRECT = 300;
     private static final int HTTP_CLIENT_ERROR = 400;
@@ -105,7 +106,7 @@ public final class HttpRequest {
         // Set Credentials
         if ((login != null) && (password != null)) {
             final String credentials = login + ":" + password;
-            final String encoded = new String(Base64.encode(credentials.getBytes("UTF-8"), Base64.NO_WRAP), "UTF-8");
+            final String encoded = new String(Base64.encode(credentials.getBytes(UTF8), Base64.NO_WRAP), UTF8);
             urlConnection.setRequestProperty("Authorization", "Basic " + encoded);
         }
 
@@ -124,7 +125,7 @@ public final class HttpRequest {
             }
         }
 
-        final byte[] contentAsBytes = content.getBytes("UTF-8");
+        final byte[] contentAsBytes = content.getBytes(UTF8);
 
         // write output - see http://developer.android.com/reference/java/net/HttpURLConnection.html
         urlConnection.setRequestMethod(method.name());
@@ -184,9 +185,9 @@ public final class HttpRequest {
             }
             final Object preliminaryValue = entry.getValue();
             final Object value = (preliminaryValue == null) ? "" : preliminaryValue;
-            dataBfr.append(URLEncoder.encode(entry.getKey().toString(), "UTF-8"));
+            dataBfr.append(URLEncoder.encode(entry.getKey().toString(), UTF8));
             dataBfr.append('=');
-            dataBfr.append(URLEncoder.encode(value.toString(), "UTF-8"));
+            dataBfr.append(URLEncoder.encode(value.toString(), UTF8));
         }
 
         return dataBfr.toString();


### PR DESCRIPTION
I missed some annotations in #389, that's why they are here. Same goes for typos in #390 .
Removed an unnecessary context reference, see https://github.com/F43nd1r/acra/commit/1cb7f2318147bf1992ee66d69978cb5d8e15b4ed#commitcomment-16677096
Replaced boxed values with primitives, see https://github.com/ACRA/acra/pull/390#issuecomment-196323889