### PR TITLE
Removing ability to configure reports to NOT send at shutdown.

### DIFF
--- a/src/main/java/org/acra/ACRAConstants.java
+++ b/src/main/java/org/acra/ACRAConstants.java
@@ -131,8 +131,6 @@ public final class ACRAConstants {
 
     public static final boolean DEFAULT_SEND_REPORTS_IN_DEV_MODE = true;
 
-    public static final boolean DEFAULT_SEND_REPORTS_AT_SHUTDOWN = true;
-
     public static final String DEFAULT_APPLICATION_LOGFILE = DEFAULT_STRING_VALUE;
 
     public static final int DEFAULT_APPLICATION_LOGFILE_LINES = DEFAULT_LOGCAT_LINES;

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -479,13 +479,9 @@ public @interface ReportsCrashes {
     boolean sendReportsInDevMode() default ACRAConstants.DEFAULT_SEND_REPORTS_IN_DEV_MODE;
 
     /**
-     * Set this to false if you want to disable sending reports at the time the
-     * exception is caught. In this case, reports will not be sent until the
-     * application is restarted.
-     *
-     * @return false if reports should not be sent.
+     * @deprecated since 4.8.3 no replacement. Now that we are using the SenderService in a separate process it is always safe to send at shutdown.
      */
-    boolean sendReportsAtShutdown() default ACRAConstants.DEFAULT_SEND_REPORTS_AT_SHUTDOWN;
+    boolean sendReportsAtShutdown() default true;
 
     /**
      * Provide here regex patterns to be evaluated on each SharedPreference key

--- a/src/main/java/org/acra/builder/ReportExecutor.java
+++ b/src/main/java/org/acra/builder/ReportExecutor.java
@@ -174,10 +174,6 @@ public final class ReportExecutor {
         final File reportFile = getReportFileName(crashReportData);
         saveCrashReportFile(reportFile, crashReportData);
 
-        if (reportBuilder.isEndApplication() && !config.sendReportsAtShutdown()) {
-            endApplication(reportBuilder.getUncaughtExceptionThread(), reportBuilder.getException());
-        }
-
         final SharedPreferences prefs = new SharedPreferencesFactory(context, config).create();
         if (reportingInteractionMode == ReportingInteractionMode.SILENT
                 || reportingInteractionMode == ReportingInteractionMode.TOAST

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -112,7 +112,6 @@ public final class ACRAConfiguration implements Serializable {
     private int socketTimeout;
     private boolean logcatFilterByPid;
     private boolean sendReportsInDevMode;
-    private boolean sendReportsAtShutdown;
 
     private String[] excludeMatchingSharedPreferencesKeys;
     private String[] excludeMatchingSettingsKeys;
@@ -171,7 +170,6 @@ public final class ACRAConfiguration implements Serializable {
         socketTimeout = builder.socketTimeout();
         logcatFilterByPid = builder.logcatFilterByPid();
         sendReportsInDevMode = builder.sendReportsInDevMode();
-        sendReportsAtShutdown = builder.sendReportsAtShutdown();
         excludeMatchingSharedPreferencesKeys = copyArray(builder.excludeMatchingSharedPreferencesKeys());
         excludeMatchingSettingsKeys = copyArray(builder.excludeMatchingSettingsKeys());
         buildConfigClass = builder.buildConfigClass();
@@ -707,18 +705,11 @@ public final class ACRAConfiguration implements Serializable {
     }
 
     /**
-     * @param sendReportsAtShutdown
-     *            false if you want to disable sending reports at the time the
-     *            exception is caught. Reports will be sent when the application
-     *            is restarted.
-     * @return The updated ACRA configuration
-     *
-     * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
+     * @deprecated since 4.8.1 no replacement. Now that we are using the SenderService in a separate process it is always safe to send at shutdown.
      */
     @NonNull
     @SuppressWarnings( "unused" )
     public ACRAConfiguration setSendReportsAtShutdown(boolean sendReportsAtShutdown) {
-        this.sendReportsAtShutdown = sendReportsAtShutdown;
         return this;
     }
 
@@ -1028,11 +1019,6 @@ public final class ACRAConfiguration implements Serializable {
     @SuppressWarnings("unused")
     public boolean sendReportsInDevMode() {
         return sendReportsInDevMode;
-    }
-
-    @SuppressWarnings("unused")
-    public boolean sendReportsAtShutdown() {
-        return sendReportsAtShutdown;
     }
 
     @NonNull

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -91,7 +91,6 @@ public final class ConfigurationBuilder {
     private Integer socketTimeout;
     private Boolean logcatFilterByPid;
     private Boolean sendReportsInDevMode;
-    private Boolean sendReportsAtShutdown;
 
     private String[] excludeMatchingSharedPreferencesKeys;
     private String[] excludeMatchingSettingsKeys;
@@ -152,7 +151,6 @@ public final class ConfigurationBuilder {
             socketTimeout = annotationConfig.socketTimeout();
             logcatFilterByPid = annotationConfig.logcatFilterByPid();
             sendReportsInDevMode = annotationConfig.sendReportsInDevMode();
-            sendReportsAtShutdown = annotationConfig.sendReportsAtShutdown();
             excludeMatchingSharedPreferencesKeys = annotationConfig.excludeMatchingSharedPreferencesKeys();
             excludeMatchingSettingsKeys = annotationConfig.excludeMatchingSettingsKeys();
             buildConfigClass = annotationConfig.buildConfigClass();
@@ -652,17 +650,11 @@ public final class ConfigurationBuilder {
     }
 
     /**
-     * 
-     * @param sendReportsAtShutdown
-     *            false if you want to disable sending reports at the time the
-     *            exception is caught. Reports will be sent when the application
-     *            is restarted.
-     * @return The updated ACRA configuration
+     * @deprecated since 4.8.3 no replacement. Now that we are using the SenderService in a separate process it is always safe to send at shutdown.
      */
     @NonNull
     @SuppressWarnings( "unused" )
     public ConfigurationBuilder setSendReportsAtShutdown(boolean sendReportsAtShutdown) {
-        this.sendReportsAtShutdown = sendReportsAtShutdown;
         return this;
     }
 
@@ -1077,14 +1069,6 @@ public final class ConfigurationBuilder {
             return sendReportsInDevMode;
         }
         return DEFAULT_SEND_REPORTS_IN_DEV_MODE;
-    }
-
-    @SuppressWarnings("unused")
-    boolean sendReportsAtShutdown() {
-        if (sendReportsAtShutdown != null) {
-            return sendReportsAtShutdown;
-        }
-        return DEFAULT_SEND_REPORTS_AT_SHUTDOWN;
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
This was required in the past when a shutdown might stop the crash report from being sent.
Now that we are using the ReportSender from another process this is no longer the case.

Solution for #382 