### PR TITLE
Fix TrustManagerFactory not initialized when no KeyStoreFactory provided

### DIFF
--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -1085,6 +1085,7 @@ public final class ACRAConfiguration implements Serializable {
     }
 
     @SuppressWarnings("unused")
+    @Nullable
     public KeyStoreFactory keyStoreFactory() {
         return keyStoreFactory;
     }

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -756,19 +756,25 @@ public final class ConfigurationBuilder {
      *            Set this to a factory which creates a the keystore that contains the trusted certificates
      */
     @SuppressWarnings("unused")
-    public void setKeyStoreFactory(KeyStoreFactory keyStoreFactory) {
+    @NonNull
+    public ConfigurationBuilder setKeyStoreFactory(KeyStoreFactory keyStoreFactory) {
         this.keyStoreFactory = keyStoreFactory;
+        return this;
     }
 
 
     @SuppressWarnings("unused")
-    public void setReportSenderFactoryClasses(@NonNull Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses) {
+    @NonNull
+    public ConfigurationBuilder setReportSenderFactoryClasses(@NonNull Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses) {
         this.reportSenderFactoryClasses = reportSenderFactoryClasses;
+        return this;
     }
 
     @SuppressWarnings("unused")
-    public void setReportPrimerClass(@NonNull Class<? extends ReportPrimer> reportPrimerClass) {
+    @NonNull
+    public ConfigurationBuilder setReportPrimerClass(@NonNull Class<? extends ReportPrimer> reportPrimerClass) {
         this.reportPrimerClass = reportPrimerClass;
+        return this;
     }
 
 
@@ -1163,6 +1169,7 @@ public final class ConfigurationBuilder {
     }
 
     @SuppressWarnings("unused")
+    @Nullable
     KeyStoreFactory keyStoreFactory() {
         return keyStoreFactory;
     }

--- a/src/main/java/org/acra/util/HttpRequest.java
+++ b/src/main/java/org/acra/util/HttpRequest.java
@@ -12,6 +12,7 @@ import android.util.Base64;
 
 import org.acra.ACRA;
 import org.acra.config.ACRAConfiguration;
+import org.acra.security.KeyStoreFactory;
 import org.acra.sender.HttpSender.Method;
 import org.acra.sender.HttpSender.Type;
 
@@ -23,6 +24,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 import java.util.Map;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -91,10 +93,10 @@ public final class HttpRequest {
 
                 final String algorithm = TrustManagerFactory.getDefaultAlgorithm();
                 final TrustManagerFactory tmf = TrustManagerFactory.getInstance(algorithm);
+                final KeyStoreFactory keyStoreFactory = config.keyStoreFactory();
+                final KeyStore keyStore = keyStoreFactory == null ? null : keyStoreFactory.create(context);
 
-                if (config.keyStoreFactory() != null) {
-                    tmf.init(config.keyStoreFactory().create(context));
-                }
+                tmf.init(keyStore);
 
                 final SSLContext sslContext = SSLContext.getInstance("TLS");
                 sslContext.init(null, tmf.getTrustManagers(), null);


### PR DESCRIPTION
Fix #402 .

Also:
Add @Nullabale for keyStoreFactory to prevent this in the future.
Make setter in ConfigurationBuilder return itself for chained calls where missing (e.g. on setKeyStoreFactory).