### PR TITLE
Exposing ACRA.isACRASenderServiceProcess()

### DIFF
--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -266,7 +266,7 @@ public final class ACRA {
     /**
      * @return true if the current process is the process running the SenderService.
      */
-    private static boolean isACRASenderServiceProcess(@NonNull Application app) {
+    public static boolean isACRASenderServiceProcess(@NonNull Application app) {
         final String processName = getCurrentProcessName(app);
         if (ACRA.DEV_LOGGING) log.d(LOG_TAG, "ACRA processName='" + processName + "'");
         return (processName != null) && processName.endsWith(ACRA_PRIVATE_PROCESS_NAME);


### PR DESCRIPTION
Allow apps to easily avoid starting services in `Application.onCreate` when the SenderService has caused the :acra process to be started.