### PR TITLE
Adjust visibility, suppress warnings for classes intended for users

### DIFF
--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -47,6 +47,7 @@ import java.util.List;
  * @author Kevin Gaudin
  *
  */
+@SuppressWarnings({"WeakerAccess","unused"})
 public final class ACRA {
     private ACRA(){}
 
@@ -345,7 +346,6 @@ public final class ACRA {
      * @deprecated since 4.8.0 {@link ACRAConfiguration} should be passed into classes instead of retrieved statically.
      */
     @NonNull
-    @SuppressWarnings( "unused" )
     public static ACRAConfiguration getConfig() {
         if (configProxy == null) {
             throw new IllegalStateException("Cannot call ACRA.getConfig() before ACRA.init().");
@@ -359,7 +359,6 @@ public final class ACRA {
      * @deprecated since 4.8.0 use {@link ConfigurationBuilder} instead.
      */
     @NonNull
-    @SuppressWarnings( "unused" )
     public static ACRAConfiguration getNewDefaultConfig(@NonNull Application app) {
         return new ConfigurationBuilder(app).build();
     }

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -276,6 +276,7 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
      * @param e The {@link Throwable} to be reported. If null the report will
      *          contain a new Exception("Report requested by developer").
      */
+    @SuppressWarnings("unused")
     public void handleSilentException(@Nullable Throwable e) {
         performDeprecatedReportPriming();
         new ReportBuilder()

--- a/src/main/java/org/acra/collector/DisplayManagerCollector.java
+++ b/src/main/java/org/acra/collector/DisplayManagerCollector.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Field;
 final class DisplayManagerCollector {
     private DisplayManagerCollector(){}
 
-    static final SparseArray<String> mFlagsNames = new SparseArray<String>();
+    private static final SparseArray<String> mFlagsNames = new SparseArray<String>();
 
     @NonNull
     public static String collectDisplays(@NonNull Context ctx) {

--- a/src/main/java/org/acra/collector/MediaCodecListCollector.java
+++ b/src/main/java/org/acra/collector/MediaCodecListCollector.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
  *
  * @author Kevin Gaudin
  */
-public final class MediaCodecListCollector {
+final class MediaCodecListCollector {
     private MediaCodecListCollector(){}
     private enum CodecType {
         AVC, H263, MPEG4, AAC

--- a/src/main/java/org/acra/collector/ThreadCollector.java
+++ b/src/main/java/org/acra/collector/ThreadCollector.java
@@ -25,7 +25,7 @@ import android.support.annotation.Nullable;
  * @author Kevin Gaudin
  * 
  */
-public final class ThreadCollector {
+final class ThreadCollector {
     private ThreadCollector(){}
 
     /**

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -55,6 +55,7 @@ import static org.acra.ACRA.LOG_TAG;
  *
  * Use {@link ConfigurationBuilder} to programmatically construct an ACRAConfiguration.
  */
+@SuppressWarnings("unused")
 public final class ACRAConfiguration implements Serializable {
 
     @Nullable
@@ -210,7 +211,6 @@ public final class ACRAConfiguration implements Serializable {
      *
      * @return A map associating http header names to their values.
      */
-    @SuppressWarnings("unused")
     @NonNull
     public Map<String, String> getHttpHeaders() {
         return Collections.unmodifiableMap(httpHeaders);
@@ -220,7 +220,6 @@ public final class ACRAConfiguration implements Serializable {
      * @return List of ReportField that ACRA will provide to the server.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public List<ReportField> getReportFields() {
         final ReportField[] customReportFields = customReportContent();
 
@@ -268,7 +267,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setConnectionTimeout(int connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
         return this;
@@ -292,7 +290,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setDeleteUnapprovedReportsOnApplicationStart(boolean deleteUnapprovedReportsOnApplicationStart) {
         this.deleteUnapprovedReportsOnApplicationStart = deleteUnapprovedReportsOnApplicationStart;
         return this;
@@ -304,7 +301,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setDeleteOldUnsentReportsOnApplicationStart(boolean deleteOldUnsentReportsOnApplicationStart) {
         this.deleteOldUnsentReportsOnApplicationStart = deleteOldUnsentReportsOnApplicationStart;
         return this;
@@ -316,7 +312,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setDropboxCollectionMinutes(int dropboxCollectionMinutes) {
         this.dropboxCollectionMinutes = dropboxCollectionMinutes;
         return this;
@@ -328,7 +323,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setForceCloseDialogAfterToast(boolean forceCloseDialogAfterToast) {
         this.forceCloseDialogAfterToast = forceCloseDialogAfterToast;
         return this;
@@ -342,7 +336,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setFormUri(@Nullable String formUri) {
         this.formUri = formUri;
         return this;
@@ -354,7 +347,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setFormUriBasicAuthLogin(@Nullable String formUriBasicAuthLogin) {
         this.formUriBasicAuthLogin = formUriBasicAuthLogin;
         return this;
@@ -366,7 +358,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setFormUriBasicAuthPassword(@Nullable String formUriBasicAuthPassword) {
         this.formUriBasicAuthPassword = formUriBasicAuthPassword;
         return this;
@@ -378,7 +369,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setIncludeDropboxSystemTags(boolean includeDropboxSystemTags) {
         this.includeDropBoxSystemTags = includeDropboxSystemTags;
         return this;
@@ -390,7 +380,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setLogcatArguments(@NonNull String[] logcatArguments) {
         this.logcatArguments = copyArray(logcatArguments);
         return this;
@@ -404,7 +393,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setMailTo(@Nullable String mailTo) {
         this.mailTo = mailTo;
         return this;
@@ -420,7 +408,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setMode(@NonNull ReportingInteractionMode mode) throws ACRAConfigurationException {
         this.reportingInteractionMode = mode;
         checkCrashResources();
@@ -431,7 +418,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResDialogPositiveButtonText(@StringRes int resId) {
         resDialogPositiveButtonText = resId;
         return this;
@@ -441,7 +427,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResDialogNegativeButtonText(@StringRes int resId) {
         resDialogNegativeButtonText = resId;
         return this;
@@ -451,7 +436,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setReportDialogClass(@NonNull Class<? extends BaseCrashReportDialog> reportDialogClass) {
         this.reportDialogClass = reportDialogClass;
         return this;
@@ -468,7 +452,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResDialogCommentPrompt(@StringRes int resId) {
         resDialogCommentPrompt = resId;
         return this;
@@ -485,7 +468,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResDialogEmailPrompt(@StringRes int resId) {
         resDialogEmailPrompt = resId;
         return this;
@@ -501,7 +483,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResDialogIcon(@DrawableRes int resId) {
         resDialogIcon = resId;
         return this;
@@ -517,7 +498,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResDialogOkToast(@StringRes int resId) {
         resDialogOkToast = resId;
         return this;
@@ -533,7 +513,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResDialogText(@StringRes int resId) {
         resDialogText = resId;
         return this;
@@ -549,7 +528,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResDialogTitle(@StringRes int resId) {
         resDialogTitle = resId;
         return this;
@@ -565,7 +543,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResNotifIcon(@DrawableRes int resId) {
         resNotifIcon = resId;
         return this;
@@ -581,7 +558,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResNotifText(@StringRes int resId) {
         resNotifText = resId;
         return this;
@@ -598,7 +574,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResNotifTickerText(@StringRes int resId) {
         resNotifTickerText = resId;
         return this;
@@ -614,7 +589,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResNotifTitle(@StringRes int resId) {
         resNotifTitle = resId;
         return this;
@@ -630,7 +604,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setResToastText(@StringRes int resId) {
         resToastText = resId;
         return this;
@@ -642,7 +615,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setSharedPreferenceMode(int sharedPreferenceMode) {
         this.sharedPreferencesMode = sharedPreferenceMode;
         return this;
@@ -654,7 +626,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setSharedPreferenceName(@NonNull String sharedPreferenceName) {
         this.sharedPreferencesName = sharedPreferenceName;
         return this;
@@ -667,7 +638,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings( "unused" )
     public ACRAConfiguration setSocketTimeout(int socketTimeout) {
         this.socketTimeout = socketTimeout;
         return this;
@@ -683,7 +653,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings( "unused" )
     public ACRAConfiguration setLogcatFilterByPid(boolean filterByPid) {
         logcatFilterByPid = filterByPid;
         return this;
@@ -698,7 +667,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings( "unused" )
     public ACRAConfiguration setSendReportsInDevMode(boolean sendReportsInDevMode) {
         this.sendReportsInDevMode = sendReportsInDevMode;
         return this;
@@ -750,7 +718,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setBuildConfigClass(@Nullable Class buildConfigClass) {
         this.buildConfigClass = buildConfigClass;
         return this;
@@ -763,7 +730,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setApplicationLogFile(@NonNull String applicationLogFile) {
         this.applicationLogFile = applicationLogFile;
         return this;
@@ -777,7 +743,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setApplicationLogFileLines(int applicationLogFileLines) {
         this.applicationLogFileLines = applicationLogFileLines;
         return this;
@@ -789,7 +754,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setHttpMethod(@NonNull Method httpMethod) {
         this.httpMethod = httpMethod;
         return this;
@@ -801,7 +765,6 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
     @NonNull
-    @SuppressWarnings("unused")
     public ACRAConfiguration setReportType(@NonNull Type type) {
         reportType = type;
         return this;
@@ -811,7 +774,6 @@ public final class ACRAConfiguration implements Serializable {
      * @param keyStore Set this to the keystore that contains the trusted certificates
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
-    @SuppressWarnings("unused")
     public void setKeyStore(@Nullable KeyStore keyStore) {
         throw new UnsupportedOperationException("This method is not supported anymore");
     }
@@ -819,18 +781,15 @@ public final class ACRAConfiguration implements Serializable {
     /**
      * @deprecated since 4.8.1 - configure using {@link ConfigurationBuilder} instead. ACRAConfiguration will become immutable in the near future.
      */
-    @SuppressWarnings("unused")
     public void setReportSenderFactoryClasses(@NonNull Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses) {
         this.reportSenderFactoryClasses = copyArray(reportSenderFactoryClasses);
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public String[] additionalDropBoxTags() {
         return copyArray(additionalDropBoxTags);
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public String[] additionalSharedPreferences() {
         return copyArray(additionalSharedPreferences);
@@ -840,195 +799,161 @@ public final class ACRAConfiguration implements Serializable {
      * @deprecated since 4.8.1 no replacement.
      */
     @Nullable
-    @SuppressWarnings("unused")
     public Class<? extends Annotation> annotationType() {
         return annotationType; // Why would this ever be needed?
     }
 
-    @SuppressWarnings("unused")
     public int connectionTimeout() {
         return connectionTimeout;
     }
 
     @NonNull
-    @SuppressWarnings("unused")
     public ReportField[] customReportContent() {
         return copyArray(customReportContent);
     }
 
-    @SuppressWarnings("unused")
     public boolean deleteUnapprovedReportsOnApplicationStart() {
         return deleteUnapprovedReportsOnApplicationStart;
     }
 
-    @SuppressWarnings("unused")
     public boolean deleteOldUnsentReportsOnApplicationStart() {
         return deleteOldUnsentReportsOnApplicationStart;
     }
 
-    @SuppressWarnings("unused")
     public int dropboxCollectionMinutes() {
         return dropboxCollectionMinutes;
     }
 
-    @SuppressWarnings("unused")
     public boolean forceCloseDialogAfterToast() {
         return forceCloseDialogAfterToast;
     }
 
-    @SuppressWarnings("unused")
     @Nullable
     public String formUri() {
         return formUri;
     }
 
-    @SuppressWarnings("unused")
     @Nullable
     public String formUriBasicAuthLogin() {
         return formUriBasicAuthLogin;
     }
 
-    @SuppressWarnings("unused")
     @Nullable
     public String formUriBasicAuthPassword() {
         return formUriBasicAuthPassword;
     }
 
-    @SuppressWarnings("unused")
     public boolean includeDropBoxSystemTags() {
         return includeDropBoxSystemTags;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public String[] logcatArguments() {
         return copyArray(logcatArguments);
     }
 
-    @SuppressWarnings("unused")
     @Nullable
     public String mailTo() {
         return mailTo;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public ReportingInteractionMode mode() {
         return reportingInteractionMode;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resDialogPositiveButtonText() {
         return resDialogPositiveButtonText;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resDialogNegativeButtonText() {
         return resDialogNegativeButtonText;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resDialogCommentPrompt() {
         return resDialogCommentPrompt;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resDialogEmailPrompt() {
         return resDialogEmailPrompt;
     }
 
-    @SuppressWarnings("unused")
     @DrawableRes
     public int resDialogIcon() {
         return resDialogIcon;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resDialogOkToast() {
         return resDialogOkToast;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resDialogText() {
         return resDialogText;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resDialogTitle() {
         return resDialogTitle;
     }
 
-    @SuppressWarnings("unused")
     @DrawableRes
     public int resNotifIcon() {
         return resNotifIcon;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resNotifText() {
         return resNotifText;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resNotifTickerText() {
         return resNotifTickerText;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resNotifTitle() {
         return resNotifTitle;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resToastText() {
         return resToastText;
     }
 
-    @SuppressWarnings("unused")
     public int sharedPreferencesMode() {
         return sharedPreferencesMode;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public String sharedPreferencesName() {
         return sharedPreferencesName;
     }
 
-    @SuppressWarnings("unused")
     public int socketTimeout() {
         return socketTimeout;
     }
 
-    @SuppressWarnings("unused")
     public boolean logcatFilterByPid() {
         return logcatFilterByPid;
     }
 
-    @SuppressWarnings("unused")
     public boolean sendReportsInDevMode() {
         return sendReportsInDevMode;
     }
 
     @NonNull
-    @SuppressWarnings("unused")
     public String[] excludeMatchingSharedPreferencesKeys() {
         return copyArray(excludeMatchingSharedPreferencesKeys);
     }
 
     @NonNull
-    @SuppressWarnings("unused")
     public String[] excludeMatchingSettingsKeys() {
         return copyArray(excludeMatchingSettingsKeys);
     }
@@ -1038,53 +963,44 @@ public final class ACRAConfiguration implements Serializable {
      * It is up to clients to construct the recommended default value oof context.getClass().getPackage().getName() + BuildConfig.class
      */
     @Nullable
-    @SuppressWarnings("unused")
     public Class buildConfigClass() {
         return buildConfigClass;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public String applicationLogFile() {
         return applicationLogFile;
     }
 
-    @SuppressWarnings("unused")
     public int applicationLogFileLines() {
         return applicationLogFileLines;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public Class<? extends BaseCrashReportDialog> reportDialogClass() {
         return reportDialogClass;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public Class<? extends ReportPrimer> reportPrimerClass() {
         return reportPrimerClass;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public Method httpMethod() {
         return httpMethod;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public Type reportType() {
         return reportType;
     }
 
     @NonNull
-    @SuppressWarnings("unused")
     public Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses() {
         return copyArray(reportSenderFactoryClasses);
     }
 
-    @SuppressWarnings("unused")
     @Nullable
     public KeyStoreFactory keyStoreFactory() {
         return keyStoreFactory;

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -183,7 +183,6 @@ public final class ConfigurationBuilder {
      * @return The updated ACRA configuration
      */
     @NonNull
-    @SuppressWarnings( "unused" )
     public ConfigurationBuilder setHttpHeaders(@NonNull Map<String, String> headers) {
         this.httpHeaders.clear();
         this.httpHeaders.putAll(headers);
@@ -755,22 +754,18 @@ public final class ConfigurationBuilder {
      * @param keyStoreFactory
      *            Set this to a factory which creates a the keystore that contains the trusted certificates
      */
-    @SuppressWarnings("unused")
     @NonNull
     public ConfigurationBuilder setKeyStoreFactory(KeyStoreFactory keyStoreFactory) {
         this.keyStoreFactory = keyStoreFactory;
         return this;
     }
 
-
-    @SuppressWarnings("unused")
     @NonNull
     public ConfigurationBuilder setReportSenderFactoryClasses(@NonNull Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses) {
         this.reportSenderFactoryClasses = reportSenderFactoryClasses;
         return this;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     public ConfigurationBuilder setReportPrimerClass(@NonNull Class<? extends ReportPrimer> reportPrimerClass) {
         this.reportPrimerClass = reportPrimerClass;
@@ -780,7 +775,6 @@ public final class ConfigurationBuilder {
 
     // Getters - used to provide values and !DEFAULTS! to ACRConfiguration during construction
 
-    @SuppressWarnings("unused")
     @NonNull
     String[] additionalDropBoxTags() {
         if (additionalDropBoxTags != null) {
@@ -789,7 +783,6 @@ public final class ConfigurationBuilder {
         return new String[0];
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String[] additionalSharedPreferences() {
         if (additionalSharedPreferences != null) {
@@ -802,12 +795,10 @@ public final class ConfigurationBuilder {
      * @deprecated since 4.8.1 no replacement.
      */
     @Nullable
-    @SuppressWarnings("unused")
     Class<? extends Annotation> annotationType() {
         return annotationType; // Why would this ever be needed?
     }
 
-    @SuppressWarnings("unused")
     int connectionTimeout() {
         if (connectionTimeout != null) {
             return connectionTimeout;
@@ -815,7 +806,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_CONNECTION_TIMEOUT;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     ReportField[] customReportContent() {
         if (customReportContent != null) {
@@ -824,7 +814,6 @@ public final class ConfigurationBuilder {
         return new ReportField[0];
     }
 
-    @SuppressWarnings("unused")
     boolean deleteUnapprovedReportsOnApplicationStart() {
         if (deleteUnapprovedReportsOnApplicationStart != null) {
             return deleteUnapprovedReportsOnApplicationStart;
@@ -832,7 +821,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_DELETE_UNAPPROVED_REPORTS_ON_APPLICATION_START;
     }
 
-    @SuppressWarnings("unused")
     boolean deleteOldUnsentReportsOnApplicationStart() {
         if (deleteOldUnsentReportsOnApplicationStart != null) {
             return deleteOldUnsentReportsOnApplicationStart;
@@ -840,7 +828,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_DELETE_OLD_UNSENT_REPORTS_ON_APPLICATION_START;
     }
 
-    @SuppressWarnings("unused")
     int dropboxCollectionMinutes() {
         if (dropboxCollectionMinutes != null) {
             return dropboxCollectionMinutes;
@@ -848,7 +835,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_DROPBOX_COLLECTION_MINUTES;
     }
 
-    @SuppressWarnings("unused")
     boolean forceCloseDialogAfterToast() {
         if (forceCloseDialogAfterToast != null) {
             return forceCloseDialogAfterToast;
@@ -856,7 +842,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_FORCE_CLOSE_DIALOG_AFTER_TOAST;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String formUri() {
         if (formUri != null) {
@@ -865,7 +850,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_STRING_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String formUriBasicAuthLogin() {
         if (formUriBasicAuthLogin != null) {
@@ -874,7 +858,6 @@ public final class ConfigurationBuilder {
         return NULL_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String formUriBasicAuthPassword() {
         if (formUriBasicAuthPassword != null) {
@@ -883,7 +866,6 @@ public final class ConfigurationBuilder {
         return NULL_VALUE;
     }
 
-    @SuppressWarnings("unused")
     boolean includeDropBoxSystemTags() {
         if (includeDropBoxSystemTags != null) {
             return includeDropBoxSystemTags;
@@ -891,7 +873,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_INCLUDE_DROPBOX_SYSTEM_TAGS;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String[] logcatArguments() {
         if (logcatArguments != null) {
@@ -900,7 +881,6 @@ public final class ConfigurationBuilder {
         return new String[] { "-t", Integer.toString(DEFAULT_LOGCAT_LINES), "-v", "time" };
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String mailTo() {
         if (mailTo != null) {
@@ -909,7 +889,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_STRING_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     ReportingInteractionMode reportingInteractionMode() {
         if (reportingInteractionMode != null) {
@@ -918,7 +897,6 @@ public final class ConfigurationBuilder {
         return ReportingInteractionMode.SILENT;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     public int resDialogPositiveButtonText() {
         if (resDialogPositiveButtonText != null) {
@@ -927,7 +905,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resDialogNegativeButtonText() {
         if (resDialogNegativeButtonText != null) {
@@ -936,7 +913,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resDialogCommentPrompt() {
         if (resDialogCommentPrompt != null) {
@@ -945,7 +921,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resDialogEmailPrompt() {
         if (resDialogEmailPrompt != null) {
@@ -954,7 +929,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @DrawableRes
     int resDialogIcon() {
         if (resDialogIcon != null) {
@@ -963,7 +937,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_DIALOG_ICON;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resDialogOkToast() {
         if (resDialogOkToast != null) {
@@ -972,7 +945,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resDialogText() {
         if (resDialogText != null) {
@@ -981,7 +953,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resDialogTitle() {
         if (resDialogTitle != null) {
@@ -990,7 +961,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @DrawableRes
     int resNotifIcon() {
         if (resNotifIcon != null) {
@@ -999,7 +969,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_NOTIFICATION_ICON;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resNotifText() {
         if (resNotifText != null) {
@@ -1008,7 +977,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resNotifTickerText() {
         if (resNotifTickerText != null) {
@@ -1017,7 +985,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resNotifTitle() {
         if (resNotifTitle != null) {
@@ -1026,7 +993,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     @StringRes
     int resToastText() {
         if (resToastText != null) {
@@ -1035,7 +1001,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_RES_VALUE;
     }
 
-    @SuppressWarnings("unused")
     int sharedPreferencesMode() {
         if (sharedPreferencesMode != null) {
             return sharedPreferencesMode;
@@ -1043,7 +1008,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_SHARED_PREFERENCES_MODE;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String sharedPreferencesName() {
         if (sharedPreferencesName != null) {
@@ -1053,7 +1017,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_STRING_VALUE;
     }
 
-    @SuppressWarnings("unused")
     int socketTimeout() {
         if (socketTimeout != null) {
             return socketTimeout;
@@ -1061,7 +1024,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_SOCKET_TIMEOUT;
     }
 
-    @SuppressWarnings("unused")
     boolean logcatFilterByPid() {
         if (logcatFilterByPid != null) {
             return logcatFilterByPid;
@@ -1069,7 +1031,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_LOGCAT_FILTER_BY_PID;
     }
 
-    @SuppressWarnings("unused")
     boolean sendReportsInDevMode() {
         if (sendReportsInDevMode != null) {
             return sendReportsInDevMode;
@@ -1077,7 +1038,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_SEND_REPORTS_IN_DEV_MODE;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String[] excludeMatchingSharedPreferencesKeys() {
         if (excludeMatchingSharedPreferencesKeys != null) {
@@ -1086,7 +1046,6 @@ public final class ConfigurationBuilder {
         return new String[0];
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String[] excludeMatchingSettingsKeys() {
         if (excludeMatchingSettingsKeys != null) {
@@ -1099,13 +1058,11 @@ public final class ConfigurationBuilder {
      * Will return null if no value has been configured.
      * It is up to clients to construct the recommended default value oof context.getClass().getPackage().getName() + BuildConfig.class
      */
-    @SuppressWarnings("unused")
     @Nullable
     Class buildConfigClass() {
         return buildConfigClass;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     String applicationLogFile() {
         if (applicationLogFile != null) {
@@ -1114,7 +1071,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_APPLICATION_LOGFILE;
     }
 
-    @SuppressWarnings("unused")
     int applicationLogFileLines() {
         if (applicationLogFileLines != null) {
             return applicationLogFileLines;
@@ -1122,7 +1078,6 @@ public final class ConfigurationBuilder {
         return DEFAULT_APPLICATION_LOGFILE_LINES;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     Class<? extends BaseCrashReportDialog> reportDialogClass() {
         if (reportDialogClass != null) {
@@ -1131,7 +1086,6 @@ public final class ConfigurationBuilder {
         return CrashReportDialog.class;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     Class<? extends ReportPrimer> reportPrimerClass() {
         if (reportPrimerClass != null) {
@@ -1140,7 +1094,6 @@ public final class ConfigurationBuilder {
         return NoOpReportPrimer.class;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     Method httpMethod() {
         if (httpMethod != null) {
@@ -1149,7 +1102,6 @@ public final class ConfigurationBuilder {
         return Method.POST;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     Type reportType() {
         if (reportType != null) {
@@ -1158,7 +1110,6 @@ public final class ConfigurationBuilder {
         return Type.FORM;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
     Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses() {
         if (reportSenderFactoryClasses != null) {
@@ -1168,7 +1119,6 @@ public final class ConfigurationBuilder {
         return new Class[] {DefaultReportSenderFactory.class};
     }
 
-    @SuppressWarnings("unused")
     @Nullable
     KeyStoreFactory keyStoreFactory() {
         return keyStoreFactory;

--- a/src/main/java/org/acra/dialog/BaseCrashReportDialog.java
+++ b/src/main/java/org/acra/dialog/BaseCrashReportDialog.java
@@ -38,6 +38,7 @@ import static org.acra.ReportField.USER_EMAIL;
  * <li>{@link ACRAConstants#EXTRA_FORCE_CANCEL} (optional)</li>
  * </ol>
  */
+@SuppressWarnings({"WeakerAccess", "unused"})
 public abstract class BaseCrashReportDialog extends Activity {
 
     private File reportFile;

--- a/src/main/java/org/acra/dialog/CrashReportDialog.java
+++ b/src/main/java/org/acra/dialog/CrashReportDialog.java
@@ -25,6 +25,7 @@ import org.acra.prefs.SharedPreferencesFactory;
  * to send reports. Requires android:launchMode="singleInstance" in your
  * AndroidManifest to work properly.
  **/
+@SuppressWarnings({"WeakerAccess", "unused"})
 public class CrashReportDialog extends BaseCrashReportDialog implements DialogInterface.OnClickListener, DialogInterface.OnDismissListener {
 
     private static final String STATE_EMAIL = "email";
@@ -50,9 +51,10 @@ public class CrashReportDialog extends BaseCrashReportDialog implements DialogIn
 
     /**
      * Build the dialog from the values in config
+     *
      * @param savedInstanceState old state to restore
      */
-    protected void buildAndShowDialog(@Nullable Bundle savedInstanceState){
+    protected void buildAndShowDialog(@Nullable Bundle savedInstanceState) {
         final AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(this);
         final int titleResourceId = getConfig().resDialogTitle();
         if (titleResourceId != ACRAConstants.DEFAULT_RES_VALUE) {
@@ -85,7 +87,7 @@ public class CrashReportDialog extends BaseCrashReportDialog implements DialogIn
 
         // Add an optional prompt for user comments
         View comment = getCommentLabel();
-        if(comment != null){
+        if (comment != null) {
             comment.setPadding(comment.getPaddingLeft(), PADDING, comment.getPaddingRight(), comment.getPaddingBottom());
             addViewToDialog(comment);
             String savedComment = null;
@@ -98,7 +100,7 @@ public class CrashReportDialog extends BaseCrashReportDialog implements DialogIn
 
         // Add an optional user email field
         View email = getEmailLabel();
-        if(email != null){
+        if (email != null) {
             email.setPadding(email.getPaddingLeft(), PADDING, email.getPaddingRight(), email.getPaddingBottom());
             addViewToDialog(email);
             String savedEmail = null;
@@ -137,6 +139,7 @@ public class CrashReportDialog extends BaseCrashReportDialog implements DialogIn
 
     /**
      * creates a comment label view with resDialogCommentPrompt as text
+     *
      * @return the label or null if there is no resource
      */
     @Nullable
@@ -168,10 +171,11 @@ public class CrashReportDialog extends BaseCrashReportDialog implements DialogIn
 
     /**
      * creates a email label view with resDialogEmailPrompt as text
+     *
      * @return the label or null if there is no resource
      */
     @Nullable
-    protected View getEmailLabel(){
+    protected View getEmailLabel() {
         final int emailPromptId = getConfig().resDialogEmailPrompt();
         if (emailPromptId != ACRAConstants.DEFAULT_RES_VALUE) {
             final TextView labelView = new TextView(this);

--- a/src/main/java/org/acra/file/LastModifiedComparator.java
+++ b/src/main/java/org/acra/file/LastModifiedComparator.java
@@ -8,7 +8,7 @@ import java.util.Comparator;
 /**
  * Orders files from oldest to newest based on their last modified date.
  */
-public final class LastModifiedComparator implements Comparator<File> {
+final class LastModifiedComparator implements Comparator<File> {
     @Override
     public int compare(@NonNull File lhs, @NonNull File rhs) {
         return (int) (lhs.lastModified() - rhs.lastModified());

--- a/src/main/java/org/acra/log/HollowLog.java
+++ b/src/main/java/org/acra/log/HollowLog.java
@@ -6,7 +6,7 @@ import android.support.annotation.Nullable;
  * Stub implementation of {@link org.acra.log.ACRALog}, quenches all logging.
  */
 @SuppressWarnings("unused")
-public class HollowLog implements ACRALog {
+public final class HollowLog implements ACRALog {
     @Override
     public int v(String tag, String msg) {
         return 0;

--- a/src/main/java/org/acra/log/HollowLog.java
+++ b/src/main/java/org/acra/log/HollowLog.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 /**
  * Stub implementation of {@link org.acra.log.ACRALog}, quenches all logging.
  */
+@SuppressWarnings("unused")
 public class HollowLog implements ACRALog {
     @Override
     public int v(String tag, String msg) {

--- a/src/main/java/org/acra/security/AssetKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/AssetKeyStoreFactory.java
@@ -32,7 +32,7 @@ import static org.acra.ACRA.LOG_TAG;
  * @since 4.8.3
  */
 @SuppressWarnings("unused")
-public class AssetKeyStoreFactory extends BaseKeyStoreFactory {
+public final class AssetKeyStoreFactory extends BaseKeyStoreFactory {
 
     private final String assetName;
 

--- a/src/main/java/org/acra/security/AssetKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/AssetKeyStoreFactory.java
@@ -31,6 +31,7 @@ import static org.acra.ACRA.LOG_TAG;
  * @author F43nd1r
  * @since 4.8.3
  */
+@SuppressWarnings("unused")
 public class AssetKeyStoreFactory extends BaseKeyStoreFactory {
 
     private final String assetName;

--- a/src/main/java/org/acra/security/BaseKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/BaseKeyStoreFactory.java
@@ -39,6 +39,7 @@ import static org.acra.ACRA.LOG_TAG;
  * @author F43nd1r
  * @since 4.8.3
  */
+@SuppressWarnings("WeakerAccess")
 public abstract class BaseKeyStoreFactory implements KeyStoreFactory {
 
     private final String certificateType;

--- a/src/main/java/org/acra/security/FileKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/FileKeyStoreFactory.java
@@ -33,7 +33,7 @@ import static org.acra.ACRA.LOG_TAG;
  * @since 4.8.3
  */
 @SuppressWarnings("unused")
-public class FileKeyStoreFactory extends BaseKeyStoreFactory {
+public final class FileKeyStoreFactory extends BaseKeyStoreFactory {
 
     private final String filePath;
 

--- a/src/main/java/org/acra/security/FileKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/FileKeyStoreFactory.java
@@ -32,6 +32,7 @@ import static org.acra.ACRA.LOG_TAG;
  * @author F43nd1r
  * @since 4.8.3
  */
+@SuppressWarnings("unused")
 public class FileKeyStoreFactory extends BaseKeyStoreFactory {
 
     private final String filePath;

--- a/src/main/java/org/acra/security/ResourceKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/ResourceKeyStoreFactory.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
  * @author F43nd1r
  * @since 4.8.3
  */
+@SuppressWarnings("unused")
 public class ResourceKeyStoreFactory extends BaseKeyStoreFactory {
 
     @RawRes

--- a/src/main/java/org/acra/security/ResourceKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/ResourceKeyStoreFactory.java
@@ -28,7 +28,7 @@ import java.io.InputStream;
  * @since 4.8.3
  */
 @SuppressWarnings("unused")
-public class ResourceKeyStoreFactory extends BaseKeyStoreFactory {
+public final class ResourceKeyStoreFactory extends BaseKeyStoreFactory {
 
     @RawRes
     private final int rawRes;


### PR DESCRIPTION
Hide some classes which don't need to be public.
Supress Warnings for classes and methods intended for usage in the final application (not the library itself).