### PR TITLE
Keystorefactory: Pass class instead of object

### DIFF
--- a/src/main/java/org/acra/ACRAConstants.java
+++ b/src/main/java/org/acra/ACRAConstants.java
@@ -157,4 +157,6 @@ public final class ACRAConstants {
             INSTALLATION_ID, DEVICE_FEATURES, ENVIRONMENT, SHARED_PREFERENCES };
 
     public static final String DATE_TIME_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ";
+
+    public static final String DEFAULT_CERTIFICATE_TYPE = "X.509";
 }

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -20,6 +20,7 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
+import android.support.annotation.RawRes;
 import android.support.annotation.StringRes;
 
 import org.acra.ACRA;
@@ -30,6 +31,8 @@ import org.acra.builder.NoOpReportPrimer;
 import org.acra.builder.ReportPrimer;
 import org.acra.dialog.BaseCrashReportDialog;
 import org.acra.dialog.CrashReportDialog;
+import org.acra.security.KeyStoreFactory;
+import org.acra.security.NoKeyStoreFactory;
 import org.acra.sender.DefaultReportSenderFactory;
 import org.acra.sender.HttpSender.Method;
 import org.acra.sender.HttpSender.Type;
@@ -561,4 +564,24 @@ public @interface ReportsCrashes {
     @NonNull Method httpMethod() default Method.POST;
 
     @NonNull Type reportType() default Type.FORM;
+
+    /**
+     * @return Class which creates a keystore that can contain trusted certificates
+     */
+    @NonNull Class<? extends KeyStoreFactory> keyStoreFactoryClass() default NoKeyStoreFactory.class;
+
+    /**
+     * @return path to a custom trusted certificate. Must start with "asset://" if the file is in the assets folder
+     */
+    @NonNull String certificatePath() default ACRAConstants.DEFAULT_STRING_VALUE;
+
+    /**
+     * @return resource id of a custom trusted certificate.
+     */
+    @RawRes int resCertificate() default ACRAConstants.DEFAULT_RES_VALUE;
+
+    /**
+     * @return specify the type of the certificate set in either {@link #certificatePath()} or {@link #resCertificate()}
+     */
+    @NonNull String certificateType() default ACRAConstants.DEFAULT_CERTIFICATE_TYPE;
 }

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -127,7 +127,7 @@ public final class ACRAConfiguration implements Serializable {
     private Method httpMethod;
     private Type reportType;
     private final Map<String, String> httpHeaders = new HashMap<String, String>();
-    private KeyStoreFactory keyStoreFactory;
+    private Class<? extends KeyStoreFactory> keyStoreFactoryClass;
     private Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses;
 
     /**
@@ -185,7 +185,7 @@ public final class ACRAConfiguration implements Serializable {
         httpHeaders.putAll(builder.httpHeaders());
         reportType = builder.reportType();
         reportSenderFactoryClasses = copyArray(builder.reportSenderFactoryClasses());
-        keyStoreFactory = builder.keyStoreFactory();
+        keyStoreFactoryClass = builder.keyStoreFactoryClass();
     }
 
 
@@ -996,8 +996,8 @@ public final class ACRAConfiguration implements Serializable {
     }
 
     @Nullable
-    public KeyStoreFactory keyStoreFactory() {
-        return keyStoreFactory;
+    public Class<? extends KeyStoreFactory> keyStoreFactoryClass() {
+        return keyStoreFactoryClass;
     }
 
     /**

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -19,6 +19,7 @@ import android.os.Build;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RawRes;
 import android.support.annotation.StringRes;
 
 import org.acra.ACRA;
@@ -129,6 +130,10 @@ public final class ACRAConfiguration implements Serializable {
     private final Map<String, String> httpHeaders = new HashMap<String, String>();
     private Class<? extends KeyStoreFactory> keyStoreFactoryClass;
     private Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses;
+    @RawRes
+    private int resCertificate;
+    private String certificatePath;
+    private String certificateType;
 
     /**
      * @param builder ConfigurationBuilder with which to initialise this {@link ACRAConfiguration}.
@@ -186,6 +191,9 @@ public final class ACRAConfiguration implements Serializable {
         reportType = builder.reportType();
         reportSenderFactoryClasses = copyArray(builder.reportSenderFactoryClasses());
         keyStoreFactoryClass = builder.keyStoreFactoryClass();
+        resCertificate = builder.resCertificate();
+        certificatePath = builder.certificatePath();
+        certificateType = builder.certificateType();
     }
 
 
@@ -995,9 +1003,22 @@ public final class ACRAConfiguration implements Serializable {
         return copyArray(reportSenderFactoryClasses);
     }
 
-    @Nullable
+    @NonNull
     public Class<? extends KeyStoreFactory> keyStoreFactoryClass() {
         return keyStoreFactoryClass;
+    }
+
+    @RawRes
+    public int resCertificate() {
+        return resCertificate;
+    }
+
+    public String certificatePath() {
+        return certificatePath;
+    }
+
+    public String certificateType() {
+        return certificateType;
     }
 
     /**

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -687,7 +687,7 @@ public final class ConfigurationBuilder {
     }
 
     /**
-     * @param keyStoreFactory Set this to a factory which creates a the keystore that contains the trusted certificates
+     * @param keyStoreFactoryClass Set this to a factory class which creates a the keystore that contains the trusted certificates
      */
     @NonNull
     public ConfigurationBuilder setKeyStoreFactoryClass(Class<?extends KeyStoreFactory> keyStoreFactoryClass) {

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -19,6 +19,7 @@ import android.app.Application;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RawRes;
 import android.support.annotation.StringRes;
 
 import org.acra.ACRA;
@@ -31,6 +32,7 @@ import org.acra.builder.ReportPrimer;
 import org.acra.dialog.BaseCrashReportDialog;
 import org.acra.dialog.CrashReportDialog;
 import org.acra.security.KeyStoreFactory;
+import org.acra.security.NoKeyStoreFactory;
 import org.acra.sender.DefaultReportSenderFactory;
 import org.acra.sender.HttpSender;
 import org.acra.sender.HttpSender.Method;
@@ -91,8 +93,8 @@ public final class ConfigurationBuilder {
     @DrawableRes private Integer resNotifIcon;
     @StringRes private Integer resNotifText;
     @StringRes private Integer resNotifTickerText;
-    @StringRes  private Integer resNotifTitle;
-    @StringRes   private Integer resToastText;
+    @StringRes private Integer resNotifTitle;
+    @StringRes private Integer resToastText;
     private Integer sharedPreferencesMode;
     private String sharedPreferencesName;
     private Integer socketTimeout;
@@ -110,6 +112,10 @@ public final class ConfigurationBuilder {
     private final Map<String, String> httpHeaders = new HashMap<String, String>();
     private Class<? extends KeyStoreFactory> keyStoreFactoryClass;
     private Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses;
+    @RawRes private Integer resCertificate;
+    private String certificatePath;
+    private String certificateType;
+
 
     /**
      * Constructs a ConfigurationBuilder that is prepopulated with any
@@ -168,6 +174,10 @@ public final class ConfigurationBuilder {
             httpMethod = annotationConfig.httpMethod();
             reportType = annotationConfig.reportType();
             reportSenderFactoryClasses = annotationConfig.reportSenderFactoryClasses();
+            keyStoreFactoryClass = annotationConfig.keyStoreFactoryClass();
+            resCertificate = annotationConfig.resCertificate();
+            certificatePath = annotationConfig.certificatePath();
+            certificateType = annotationConfig.certificateType();
         } else {
             annotationType = null;
         }
@@ -688,10 +698,41 @@ public final class ConfigurationBuilder {
 
     /**
      * @param keyStoreFactoryClass Set this to a factory class which creates a the keystore that contains the trusted certificates
+     * @return this instance
      */
     @NonNull
     public ConfigurationBuilder setKeyStoreFactoryClass(Class<?extends KeyStoreFactory> keyStoreFactoryClass) {
         this.keyStoreFactoryClass = keyStoreFactoryClass;
+        return this;
+    }
+
+    /**
+     * @param resCertificate a raw resource of a custom certificate file
+     * @return this instance
+     */
+    @NonNull
+    public ConfigurationBuilder setCertificate(@RawRes int resCertificate){
+        this.resCertificate = resCertificate;
+        return this;
+    }
+
+    /**
+     * @param certificatePath path to a custom trusted certificate. Must start with "asset://" if the file is in the assets folder
+     * @return this instance
+     */
+    @NonNull
+    public ConfigurationBuilder setCertificate(@NonNull String certificatePath) {
+        this.certificatePath = certificatePath;
+        return this;
+    }
+
+    /**
+     * @param type custom certificate type
+     * @return this instance
+     */
+    @NonNull
+    public ConfigurationBuilder setCertificateType(@NonNull String type) {
+        this.certificateType = type;
         return this;
     }
 
@@ -1071,9 +1112,36 @@ public final class ConfigurationBuilder {
         return new Class[]{DefaultReportSenderFactory.class};
     }
 
-    @Nullable
+    @NonNull
     Class<? extends KeyStoreFactory> keyStoreFactoryClass() {
-        return keyStoreFactoryClass;
+        if(keyStoreFactoryClass != null) {
+            return keyStoreFactoryClass;
+        }
+        return NoKeyStoreFactory.class;
+    }
+
+    @RawRes
+    int resCertificate() {
+        if(resCertificate != null){
+            return resCertificate;
+        }
+        return DEFAULT_RES_VALUE;
+    }
+
+    @NonNull
+    String certificatePath() {
+        if(certificatePath != null){
+            return certificatePath;
+        }
+        return DEFAULT_STRING_VALUE;
+    }
+
+    @NonNull
+    String certificateType() {
+        if(certificateType != null){
+            return certificateType;
+        }
+        return DEFAULT_CERTIFICATE_TYPE;
     }
 
     @NonNull

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -108,7 +108,7 @@ public final class ConfigurationBuilder {
     private Method httpMethod;
     private Type reportType;
     private final Map<String, String> httpHeaders = new HashMap<String, String>();
-    private KeyStoreFactory keyStoreFactory;
+    private Class<? extends KeyStoreFactory> keyStoreFactoryClass;
     private Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses;
 
     /**
@@ -690,8 +690,8 @@ public final class ConfigurationBuilder {
      * @param keyStoreFactory Set this to a factory which creates a the keystore that contains the trusted certificates
      */
     @NonNull
-    public ConfigurationBuilder setKeyStoreFactory(KeyStoreFactory keyStoreFactory) {
-        this.keyStoreFactory = keyStoreFactory;
+    public ConfigurationBuilder setKeyStoreFactoryClass(Class<?extends KeyStoreFactory> keyStoreFactoryClass) {
+        this.keyStoreFactoryClass = keyStoreFactoryClass;
         return this;
     }
 
@@ -1072,8 +1072,8 @@ public final class ConfigurationBuilder {
     }
 
     @Nullable
-    KeyStoreFactory keyStoreFactory() {
-        return keyStoreFactory;
+    Class<? extends KeyStoreFactory> keyStoreFactoryClass() {
+        return keyStoreFactoryClass;
     }
 
     @NonNull

--- a/src/main/java/org/acra/security/AssetKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/AssetKeyStoreFactory.java
@@ -31,19 +31,9 @@ import static org.acra.ACRA.LOG_TAG;
  * @author F43nd1r
  * @since 4.8.3
  */
-@SuppressWarnings("unused")
-public final class AssetKeyStoreFactory extends BaseKeyStoreFactory {
+final class AssetKeyStoreFactory extends BaseKeyStoreFactory {
 
     private final String assetName;
-
-    /**
-     * creates a new KeyStoreFactory for the specified asset
-     * @param assetName the asset
-     */
-    public AssetKeyStoreFactory(String assetName) {
-        super();
-        this.assetName = assetName;
-    }
 
     /**
      * creates a new KeyStoreFactory for the specified asset with a custom certificate type
@@ -60,7 +50,7 @@ public final class AssetKeyStoreFactory extends BaseKeyStoreFactory {
         try {
             return context.getAssets().open(assetName);
         } catch (IOException e) {
-            ACRA.log.e(LOG_TAG, "", e);
+            ACRA.log.e(LOG_TAG, "Could not open certificate in asset://"+assetName, e);
         }
         return null;
     }

--- a/src/main/java/org/acra/security/BaseKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/BaseKeyStoreFactory.java
@@ -20,6 +20,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.acra.ACRA;
+import org.acra.ACRAConstants;
+import org.acra.util.IOUtils;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -39,16 +41,16 @@ import static org.acra.ACRA.LOG_TAG;
  * @author F43nd1r
  * @since 4.8.3
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({"WeakerAccess","unused"})
 public abstract class BaseKeyStoreFactory implements KeyStoreFactory {
 
     private final String certificateType;
 
     /**
-     * creates a new KeyStoreFactory for the default certificate type (X.509)
+     * creates a new KeyStoreFactory for the default certificate type {@link ACRAConstants#DEFAULT_CERTIFICATE_TYPE}
      */
     public BaseKeyStoreFactory(){
-        this("X.509");
+        this(ACRAConstants.DEFAULT_CERTIFICATE_TYPE);
     }
 
     /**
@@ -75,19 +77,15 @@ public abstract class BaseKeyStoreFactory implements KeyStoreFactory {
                 keyStore.setCertificateEntry("ca", certificate);
                 return keyStore;
             } catch (CertificateException e) {
-                ACRA.log.e(LOG_TAG, "", e);
+                ACRA.log.e(LOG_TAG, "Could not load certificate", e);
             } catch (KeyStoreException e) {
-                ACRA.log.e(LOG_TAG, "", e);
+                ACRA.log.e(LOG_TAG, "Could not load certificate", e);
             } catch (NoSuchAlgorithmException e) {
-                ACRA.log.e(LOG_TAG, "", e);
+                ACRA.log.e(LOG_TAG, "Could not load certificate", e);
             } catch (IOException e) {
-                ACRA.log.e(LOG_TAG, "", e);
+                ACRA.log.e(LOG_TAG, "Could not load certificate", e);
             } finally {
-                try {
-                    bufferedInputStream.close();
-                } catch (IOException e) {
-                    ACRA.log.e(LOG_TAG, "", e);
-                }
+                IOUtils.safeClose(bufferedInputStream);
             }
         }
         return null;

--- a/src/main/java/org/acra/security/FileKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/FileKeyStoreFactory.java
@@ -32,19 +32,9 @@ import static org.acra.ACRA.LOG_TAG;
  * @author F43nd1r
  * @since 4.8.3
  */
-@SuppressWarnings("unused")
-public final class FileKeyStoreFactory extends BaseKeyStoreFactory {
+final class FileKeyStoreFactory extends BaseKeyStoreFactory {
 
     private final String filePath;
-
-    /**
-     * creates a new KeyStoreFactory for the specified file
-     * @param filePath path to the file
-     */
-    public FileKeyStoreFactory(String filePath) {
-        super();
-        this.filePath = filePath;
-    }
 
     /**
      * creates a new KeyStoreFactory for the specified file with a custom certificate type
@@ -61,7 +51,7 @@ public final class FileKeyStoreFactory extends BaseKeyStoreFactory {
         try {
             return new FileInputStream(filePath);
         } catch (FileNotFoundException e) {
-            ACRA.log.e(LOG_TAG, "", e);
+            ACRA.log.e(LOG_TAG, "Could not find File "+filePath, e);
         }
         return null;
     }

--- a/src/main/java/org/acra/security/KeyStoreFactory.java
+++ b/src/main/java/org/acra/security/KeyStoreFactory.java
@@ -24,13 +24,11 @@ import java.security.KeyStore;
 
 /**
  * The interface can be used to provide a KeyStore with certificates.
- * Note that implementations need to be serializable.
- * (e.g. can't be anonymous inner classes of non-serializable classes)
  *
  * @author F43nd1r
  * @since 4.8.3
  */
-public interface KeyStoreFactory extends Serializable{
+public interface KeyStoreFactory {
 
     @Nullable
     KeyStore create(@NonNull Context context);

--- a/src/main/java/org/acra/security/KeyStoreHelper.java
+++ b/src/main/java/org/acra/security/KeyStoreHelper.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2016
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acra.security;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.acra.ACRA;
+import org.acra.ACRAConstants;
+import org.acra.config.ACRAConfiguration;
+
+import java.security.KeyStore;
+
+import static org.acra.ACRA.LOG_TAG;
+
+/**
+ * Helper to get a KeyStore from a configuration
+ *
+ * @author F43nd1r
+ * @since 4.8.6
+ */
+public final class KeyStoreHelper {
+    private static final String ASSET_PREFIX = "asset://";
+
+    private KeyStoreHelper() {
+    }
+
+    /**
+     * try to get the keystore
+     * @param context a context
+     * @param config the configuration
+     * @return the keystore, or null if none provided / failure
+     */
+    @Nullable
+    public static KeyStore getKeyStore(@NonNull Context context, @NonNull ACRAConfiguration config) {
+        final Class<? extends KeyStoreFactory> keyStoreFactory = config.keyStoreFactoryClass();
+        KeyStore keyStore = null;
+        try {
+            keyStore = keyStoreFactory.newInstance().create(context);
+        } catch (InstantiationException e) {
+            ACRA.log.e(LOG_TAG, "Could not get keystore from factory", e);
+        } catch (IllegalAccessException e) {
+            ACRA.log.e(LOG_TAG, "Could not get keystore from factory", e);
+        }
+        if(keyStore == null) {
+            //either users factory did not create a keystore, or the configuration is default {@link NoKeyStoreFactory}
+            final int certificateRes = config.resCertificate();
+            final String certificatePath = config.certificatePath();
+            final String certificateType = config.certificateType();
+            if(certificateRes != ACRAConstants.DEFAULT_RES_VALUE){
+                keyStore = new ResourceKeyStoreFactory(certificateType, certificateRes).create(context);
+            }else if(!certificatePath.equals(ACRAConstants.DEFAULT_STRING_VALUE)){
+                if(certificatePath.startsWith(ASSET_PREFIX)) {
+                    keyStore = new AssetKeyStoreFactory(certificateType, certificatePath.substring(ASSET_PREFIX.length())).create(context);
+                } else {
+                    keyStore = new FileKeyStoreFactory(certificateType, certificatePath).create(context);
+                }
+            }
+        }
+        return keyStore;
+    }
+}

--- a/src/main/java/org/acra/security/NoKeyStoreFactory.java
+++ b/src/main/java/org/acra/security/NoKeyStoreFactory.java
@@ -17,33 +17,20 @@ package org.acra.security;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-import android.support.annotation.RawRes;
+import android.support.annotation.Nullable;
 
-import java.io.InputStream;
+import java.security.KeyStore;
 
 /**
- * KeyStoreFactory for a certificate stored in a raw resource
+ * Default KeyStoreFactory. Does not provide any KeyStore
  *
  * @author F43nd1r
- * @since 4.8.3
+ * @since 4.8.6
  */
-final class ResourceKeyStoreFactory extends BaseKeyStoreFactory {
-
-    @RawRes
-    private final int rawRes;
-
-    /**
-     * creates a new KeyStoreFactory for the specified resource with a custom certificate type
-     * @param certificateType the certificate type
-     * @param rawRes raw resource id
-     */
-    public ResourceKeyStoreFactory(String certificateType, @RawRes int rawRes) {
-        super(certificateType);
-        this.rawRes = rawRes;
-    }
-
+public class NoKeyStoreFactory implements KeyStoreFactory {
+    @Nullable
     @Override
-    public InputStream getInputStream(@NonNull Context context) {
-        return context.getResources().openRawResource(rawRes);
+    public KeyStore create(@NonNull Context context) {
+        return null;
     }
 }

--- a/src/main/java/org/acra/util/HttpRequest.java
+++ b/src/main/java/org/acra/util/HttpRequest.java
@@ -13,6 +13,7 @@ import android.util.Base64;
 import org.acra.ACRA;
 import org.acra.config.ACRAConfiguration;
 import org.acra.security.KeyStoreFactory;
+import org.acra.security.KeyStoreHelper;
 import org.acra.sender.HttpSender.Method;
 import org.acra.sender.HttpSender.Type;
 
@@ -93,7 +94,7 @@ public final class HttpRequest {
 
                 final String algorithm = TrustManagerFactory.getDefaultAlgorithm();
                 final TrustManagerFactory tmf = TrustManagerFactory.getInstance(algorithm);
-                final KeyStore keyStore = getKeyStore(context, config);
+                final KeyStore keyStore = KeyStoreHelper.getKeyStore(context, config);
 
                 tmf.init(keyStore);
 
@@ -169,21 +170,6 @@ public final class HttpRequest {
         }
 
         urlConnection.disconnect();
-    }
-
-    @Nullable
-    private static KeyStore getKeyStore(@NonNull Context context,@NonNull ACRAConfiguration config) {
-        final Class<? extends KeyStoreFactory> keyStoreFactory = config.keyStoreFactoryClass();
-        if(keyStoreFactory != null) {
-            try {
-                return keyStoreFactory.newInstance().create(context);
-            } catch (InstantiationException e) {
-                ACRA.log.e(LOG_TAG, "Could not get keystore from factory", e);
-            } catch (IllegalAccessException e) {
-                ACRA.log.e(LOG_TAG, "Could not get keystore from factory", e);
-            }
-        }
-        return null;
     }
 
     /**


### PR DESCRIPTION
It seems to be problematic to expect every user to honor that keystorefactories have to be serializable. 
Also the keystorefactory could not be configured with the annotation.

This is why I rewrote it to pass the keystorefactory class (which doesn't have to be serializable) instead of the object to the configuration. This also decreases the size of the configuration object itself.

I also added configuration options for the 3 default certificate locations: raw resources, assets and files. (Because passing the KeyStoreFactory implementations wont work, they have no empty constructor.)