### PR TITLE
Add configuration for dialog theme

### DIFF
--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -21,6 +21,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
+import android.support.annotation.StyleRes;
 
 import org.acra.ACRA;
 import org.acra.ACRAConstants;
@@ -138,6 +139,12 @@ public @interface ReportsCrashes {
      * @return Resource id for the title in the crash dialog.
      */
     @StringRes int resDialogTitle() default ACRAConstants.DEFAULT_RES_VALUE;
+
+    /**
+     *
+     * @return resource id for the crash dialog theme
+     */
+    @StyleRes int resDialogTheme() default ACRAConstants.DEFAULT_RES_VALUE;
 
     /**
      * @return Resource id for the icon in the status bar notification. Default

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -20,6 +20,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.annotation.StyleRes;
 
 import org.acra.ACRA;
 import org.acra.ACRAConstants;
@@ -101,6 +102,8 @@ public final class ACRAConfiguration implements Serializable {
     private int resDialogText;
     @StringRes
     private int resDialogTitle;
+    @StyleRes
+    private int resDialogTheme;
     @DrawableRes
     private int resNotifIcon;
     @StringRes
@@ -164,6 +167,7 @@ public final class ACRAConfiguration implements Serializable {
         resDialogOkToast = builder.resDialogOkToast();
         resDialogText = builder.resDialogText();
         resDialogTitle = builder.resDialogTitle();
+        resDialogTheme = builder.resDialogTheme();
         resNotifIcon = builder.resNotifIcon();
         resNotifText = builder.resNotifText();
         resNotifTickerText = builder.resNotifTickerText();
@@ -894,6 +898,11 @@ public final class ACRAConfiguration implements Serializable {
     @StringRes
     public int resDialogTitle() {
         return resDialogTitle;
+    }
+
+    @StyleRes
+    public int resDialogTheme() {
+        return resDialogTheme;
     }
 
     @DrawableRes

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -20,6 +20,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.annotation.StyleRes;
 
 import org.acra.ACRA;
 import org.acra.ReportField;
@@ -87,6 +88,7 @@ public final class ConfigurationBuilder {
     @StringRes private Integer resDialogOkToast;
     @StringRes private Integer resDialogText;
     @StringRes private Integer resDialogTitle;
+    @StyleRes private Integer resDialogTheme;
     @DrawableRes private Integer resNotifIcon;
     @StringRes private Integer resNotifText;
     @StringRes private Integer resNotifTickerText;
@@ -147,6 +149,7 @@ public final class ConfigurationBuilder {
             resDialogOkToast = annotationConfig.resDialogOkToast();
             resDialogText = annotationConfig.resDialogText();
             resDialogTitle = annotationConfig.resDialogTitle();
+            resDialogTheme = annotationConfig.resDialogTheme();
             resNotifIcon = annotationConfig.resNotifIcon();
             resNotifText = annotationConfig.resNotifText();
             resNotifTickerText = annotationConfig.resNotifTickerText();
@@ -475,6 +478,16 @@ public final class ConfigurationBuilder {
     @NonNull
     public ConfigurationBuilder setResDialogTitle(@StringRes int resId) {
         resDialogTitle = resId;
+        return this;
+    }
+
+    /**
+     * @param resId The resource id, see {@link ReportsCrashes#resDialogTheme()}
+     * @return this instance
+     */
+    @NonNull
+    public ConfigurationBuilder setResDialogTheme(@StyleRes int resId) {
+        resDialogTheme = resId;
         return this;
     }
 
@@ -907,6 +920,14 @@ public final class ConfigurationBuilder {
     int resDialogTitle() {
         if (resDialogTitle != null) {
             return resDialogTitle;
+        }
+        return DEFAULT_RES_VALUE;
+    }
+
+    @StyleRes
+    int resDialogTheme() {
+        if (resDialogTheme != null) {
+            return resDialogTheme;
         }
         return DEFAULT_RES_VALUE;
     }

--- a/src/main/java/org/acra/dialog/CrashReportDialog.java
+++ b/src/main/java/org/acra/dialog/CrashReportDialog.java
@@ -45,6 +45,8 @@ public class CrashReportDialog extends BaseCrashReportDialog implements DialogIn
         scrollable = new LinearLayout(this);
         scrollable.setOrientation(LinearLayout.VERTICAL);
         sharedPreferencesFactory = new SharedPreferencesFactory(getApplicationContext(), getConfig());
+        final int themeResourceId = getConfig().resDialogTheme();
+        if(themeResourceId != ACRAConstants.DEFAULT_RES_VALUE) setTheme(themeResourceId);
 
         buildAndShowDialog(savedInstanceState);
     }


### PR DESCRIPTION
The default theme (Theme.Dialog) is not anymore up-to-date. Giving an easy option to change this and make the dialog look better and more fitting seems reasonable.