### PR TITLE
Infer ReportingInteractionMode from rest of the configuration

### DIFF
--- a/src/main/java/org/acra/ReportingInteractionMode.java
+++ b/src/main/java/org/acra/ReportingInteractionMode.java
@@ -49,5 +49,9 @@ public enum ReportingInteractionMode {
      * Direct dialog: a report confirmation dialog is displayed right after the crash.
      * Will replace {@link #NOTIFICATION} mode.
      */
-    DIALOG
+    DIALOG,
+    /**
+     * Infer the report mode from the other provided configuration options
+     */
+    INFERRED
 }

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -95,7 +95,7 @@ public @interface ReportsCrashes {
      * 
      * @return the interaction mode that you want ACRA to implement.
      */
-    @NonNull ReportingInteractionMode mode() default ReportingInteractionMode.SILENT;
+    @NonNull ReportingInteractionMode mode() default ReportingInteractionMode.INFERRED;
 
     /**
      * @return Resource id for the label of positive button in the crash dialog.

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -24,6 +24,7 @@ import android.support.annotation.StringRes;
 import android.support.annotation.StyleRes;
 
 import org.acra.ACRA;
+import org.acra.ACRAConstants;
 import org.acra.ReportField;
 import org.acra.ReportingInteractionMode;
 import org.acra.annotation.ReportsCrashes;
@@ -897,10 +898,21 @@ public final class ConfigurationBuilder {
 
     @NonNull
     ReportingInteractionMode reportingInteractionMode() {
-        if (reportingInteractionMode != null) {
+        if (reportingInteractionMode != null && reportingInteractionMode != ReportingInteractionMode.INFERRED) {
             return reportingInteractionMode;
         }
-        return ReportingInteractionMode.SILENT;
+        if (resNotifTickerText() != ACRAConstants.DEFAULT_RES_VALUE && resNotifTitle() != ACRAConstants.DEFAULT_RES_VALUE && resNotifText() != ACRAConstants.DEFAULT_RES_VALUE) {
+            return ReportingInteractionMode.NOTIFICATION;
+        }
+        else if (reportDialogClass != null && (!CrashReportDialog.class.equals(reportDialogClass()) || resDialogText() != ACRAConstants.DEFAULT_RES_VALUE)) {
+            return ReportingInteractionMode.DIALOG;
+        }
+        else if (resToastText() != ACRAConstants.DEFAULT_RES_VALUE) {
+            return ReportingInteractionMode.TOAST;
+        }
+        else {
+            return ReportingInteractionMode.SILENT;
+        }
     }
 
     @StringRes


### PR DESCRIPTION
There is no actual need to manually configure the mode, as it can be inferred from the other configuration options.