### PR TITLE
Fix: removed method used

### DIFF
--- a/src/main/java/org/acra/sender/EmailIntentSender.java
+++ b/src/main/java/org/acra/sender/EmailIntentSender.java
@@ -25,6 +25,11 @@ import org.acra.ReportField;
 import org.acra.annotation.ReportsCrashes;
 import org.acra.collector.CrashReportData;
 import org.acra.config.ACRAConfiguration;
+import org.acra.util.ImmutableSet;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Send reports through an email intent.
@@ -56,9 +61,9 @@ public class EmailIntentSender implements ReportSender {
     }
 
     private String buildBody(@NonNull CrashReportData errorContent) {
-        ReportField[] fields = config.customReportContent();
-        if(fields.length == 0) {
-            fields = ACRAConstants.DEFAULT_MAIL_REPORT_FIELDS;
+        Set<ReportField> fields = config.getReportFields();
+        if(fields.size() == 0) {
+            fields = new ImmutableSet<ReportField>(ACRAConstants.DEFAULT_MAIL_REPORT_FIELDS);
         }
 
         final StringBuilder builder = new StringBuilder();

--- a/src/main/java/org/acra/sender/HttpSender.java
+++ b/src/main/java/org/acra/sender/HttpSender.java
@@ -27,12 +27,16 @@ import org.acra.annotation.ReportsCrashes;
 import org.acra.collector.CrashReportData;
 import org.acra.config.ACRAConfiguration;
 import org.acra.util.HttpRequest;
+import org.acra.util.ImmutableSet;
 import org.acra.util.JSONReportBuilder.JSONReportException;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.acra.ACRA.LOG_TAG;
 
@@ -244,9 +248,9 @@ public class HttpSender implements ReportSender {
     @NonNull
     private Map<String, String> remap(@NonNull Map<ReportField, String> report) {
 
-        ReportField[] fields = config.customReportContent();
-        if (fields.length == 0) {
-            fields = ACRAConstants.DEFAULT_REPORT_FIELDS;
+        Set<ReportField> fields = config.getReportFields();
+        if (fields.size() == 0) {
+            fields = new ImmutableSet<ReportField>(ACRAConstants.DEFAULT_REPORT_FIELDS);
         }
 
         final Map<String, String> finalReport = new HashMap<String, String>(report.size());


### PR DESCRIPTION
I don't know how this could slip through, but ACRA didn't compile at all, because of one of the removed methods of ACRAConfiguration being used.