### PR TITLE
Fix potential NullPointer in ConfigurationBuilder.build

### DIFF
--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -198,7 +198,7 @@ public final class ConfigurationBuilder {
     @NonNull
     public ACRAConfiguration build() throws ACRAConfigurationException {
 
-        switch (reportingInteractionMode) {
+        switch (reportingInteractionMode()) {
             case TOAST:
                 if (resToastText() == DEFAULT_RES_VALUE) {
                     throw new ACRAConfigurationException("TOAST mode: you have to define the resToastText parameter in your application @ReportsCrashes() annotation.");


### PR DESCRIPTION
If no annotation is set and no mode is set, the switch lead to a NullPointer.