### PR TITLE
Allow null exception in dialog

### DIFF
--- a/src/main/java/org/acra/dialog/BaseCrashReportDialog.java
+++ b/src/main/java/org/acra/dialog/BaseCrashReportDialog.java
@@ -63,7 +63,7 @@ public abstract class BaseCrashReportDialog extends Activity {
             if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Forced reports deletion.");
             cancelReports();
             finish();
-        } else if ((sConfig instanceof ACRAConfiguration) && (sReportFile instanceof File) && (sException instanceof Throwable)) {
+        } else if ((sConfig instanceof ACRAConfiguration) && (sReportFile instanceof File) && ((sException instanceof Throwable) || sException == null)) {
             config = (ACRAConfiguration) sConfig;
             reportFile = (File) sReportFile;
             exception = (Throwable) sException;


### PR DESCRIPTION
ErrorReporter allows null exceptions, so the dialog should too.