### PR TITLE
Use list instead of set for logcatArguments

### DIFF
--- a/src/main/java/org/acra/collections/ImmutableList.java
+++ b/src/main/java/org/acra/collections/ImmutableList.java
@@ -19,6 +19,7 @@ import android.support.annotation.NonNull;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -33,6 +34,10 @@ import java.util.ListIterator;
 public final class ImmutableList<E> implements List<E>, Serializable {
 
     private final List<E> mList;
+
+    public ImmutableList(E... elements) {
+        this(Arrays.asList(elements));
+    }
 
     public ImmutableList(Collection<E> collection) {
         this.mList = new ArrayList<E>(collection);

--- a/src/main/java/org/acra/collector/LogCatCollector.java
+++ b/src/main/java/org/acra/collector/LogCatCollector.java
@@ -78,7 +78,7 @@ class LogCatCollector {
         // "-t n" argument has been introduced in FroYo (API level 8). For
         // devices with lower API level, we will have to emulate its job.
         final int tailCount;
-        final List<String> logcatArgumentsList = new ArrayList<String>(config.logcatArguments());
+        final List<String> logcatArgumentsList = config.logcatArguments();
 
         final int tailIndex = logcatArgumentsList.indexOf("-t");
         if (tailIndex > -1 && tailIndex < logcatArgumentsList.size()) {

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -25,6 +25,7 @@ import android.support.annotation.StyleRes;
 import org.acra.ReportField;
 import org.acra.ReportingInteractionMode;
 import org.acra.builder.ReportPrimer;
+import org.acra.collections.ImmutableList;
 import org.acra.dialog.BaseCrashReportDialog;
 import org.acra.security.KeyStoreFactory;
 import org.acra.sender.HttpSender.Method;
@@ -55,7 +56,7 @@ public final class ACRAConfiguration implements Serializable {
     private final String formUriBasicAuthPassword;
     private final boolean includeDropBoxSystemTags;
 
-    private final ImmutableSet<String> logcatArguments;
+    private final ImmutableList<String> logcatArguments;
     private final String mailTo;
     private final ReportingInteractionMode reportingInteractionMode;
     private final Class<? extends BaseCrashReportDialog> reportDialogClass;
@@ -128,7 +129,7 @@ public final class ACRAConfiguration implements Serializable {
         formUriBasicAuthLogin = builder.formUriBasicAuthLogin();
         formUriBasicAuthPassword = builder.formUriBasicAuthPassword();
         includeDropBoxSystemTags = builder.includeDropBoxSystemTags();
-        logcatArguments = new ImmutableSet<String>(builder.logcatArguments());
+        logcatArguments = new ImmutableList<String>(builder.logcatArguments());
         mailTo = builder.mailTo();
         reportingInteractionMode = builder.reportingInteractionMode();
         resDialogIcon = builder.resDialogIcon();
@@ -237,7 +238,7 @@ public final class ACRAConfiguration implements Serializable {
     }
 
     @NonNull
-    public ImmutableSet<String> logcatArguments() {
+    public ImmutableList<String> logcatArguments() {
         return logcatArguments;
     }
 


### PR DESCRIPTION
Because ordering might be mixed up otherwise.
I was not aware that logcatArguments is ordering-sensitive until I saw a stacktrace in one of my configurations. With a set logcat collection will crash randomly because the set mixed the arguments.