### PR TITLE
Fix annotation default mistaken as custom value

### DIFF
--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -831,7 +831,7 @@ public final class ConfigurationBuilder {
     @NonNull
     Set<ReportField> reportContent() {
         final Set<ReportField> reportContent = new HashSet<ReportField>();
-        if (customReportContent != null) {
+        if (customReportContent != null && customReportContent.length != 0) {
             if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Using custom Report Fields");
             reportContent.addAll(Arrays.asList(customReportContent));
         } else if (mailTo == null || DEFAULT_STRING_VALUE.equals(mailTo)) {


### PR DESCRIPTION
This is somewhat critical, because I'd expect that most users use the default report fields. These Reports will then include no fields at all, which renders the reports pretty useless.