### PR TITLE
Never return null for BuildConfig class

### DIFF
--- a/src/main/java/org/acra/collector/CrashReportDataFactory.java
+++ b/src/main/java/org/acra/collector/CrashReportDataFactory.java
@@ -618,7 +618,7 @@ public final class CrashReportDataFactory {
     @NonNull
     private Class<?> getBuildConfigClass() throws ClassNotFoundException {
         final Class configuredBuildConfig = config.buildConfigClass();
-        if (configuredBuildConfig != null && !configuredBuildConfig.equals(Object.class)) {
+        if (!configuredBuildConfig.equals(Object.class)) {
             // If set via annotations or programmatically then it will have a real value,
             // otherwise it will be Object.class (annotation default) or null (explicit programmatic).
             return configuredBuildConfig;

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -98,7 +98,6 @@ public final class ACRAConfiguration implements Serializable {
 
     private final ImmutableSet<String> excludeMatchingSharedPreferencesKeys;
     private final ImmutableSet<String> excludeMatchingSettingsKeys;
-    @Nullable
     private final Class buildConfigClass;
     private final String applicationLogFile;
     private final int applicationLogFileLines;
@@ -359,7 +358,7 @@ public final class ACRAConfiguration implements Serializable {
      *
      * @return Class generated at compile time containing the build config for this application.
      */
-    @Nullable
+    @NonNull
     public Class buildConfigClass() {
         return buildConfigClass;
     }

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -1102,12 +1102,15 @@ public final class ConfigurationBuilder {
     }
 
     /**
-     * Will return null if no value has been configured.
-     * It is up to clients to construct the recommended default value oof context.getClass().getPackage().getName() + BuildConfig.class
+     * Will return {@link Object} if no value has been configured.
+     * It is up to clients to construct the recommended default value of context.getClass().getPackage().getName() + BuildConfig.class
      */
-    @Nullable
+    @NonNull
     Class buildConfigClass() {
-        return buildConfigClass;
+        if(buildConfigClass != null) {
+            return buildConfigClass;
+        }
+        return Object.class;
     }
 
     @NonNull


### PR DESCRIPTION
While writing some tests I noticed that BuildConfig class is the only value which differs in the not-configured-value between the ConfigurationBuilder and the annotation. There is no real reason to keep it that way.