### PR TITLE
read logcat logs in nonblocking mode with end timeout

### DIFF
--- a/src/main/java/org/acra/ACRAConstants.java
+++ b/src/main/java/org/acra/ACRAConstants.java
@@ -129,6 +129,8 @@ public final class ACRAConstants {
 
     public static final boolean DEFAULT_LOGCAT_FILTER_BY_PID = false;
 
+    public static final boolean DEFAULT_NON_BLOCKING_READ_FOR_LOGCAT = false;
+
     public static final boolean DEFAULT_SEND_REPORTS_IN_DEV_MODE = true;
 
     public static final String DEFAULT_APPLICATION_LOGFILE = DEFAULT_STRING_VALUE;

--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -480,6 +480,14 @@ public @interface ReportsCrashes {
     boolean logcatFilterByPid() default ACRAConstants.DEFAULT_LOGCAT_FILTER_BY_PID;
 
     /**
+     * Set this to true if you want to read logcat lines in a non blocking way for your
+     * thread. It has a default timeout of 3 seconds.
+     *
+     * @return true if you want that reading of logcat lines to not block current thread.
+     */
+    boolean nonBlockingReadForLogcat() default  ACRAConstants.DEFAULT_NON_BLOCKING_READ_FOR_LOGCAT;
+
+    /**
      * Set this to false if you want to disable sending reports in development
      * mode. Only signed application packages will send reports. Default value
      * is true.

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -338,6 +338,10 @@ public final class ACRAConfiguration implements Serializable {
         return logcatFilterByPid;
     }
 
+    public boolean nonBlockingReadForLogcat() {
+        return nonBlockingReadForLogcat;
+    }
+
     public boolean sendReportsInDevMode() {
         return sendReportsInDevMode;
     }

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -94,6 +94,7 @@ public final class ACRAConfiguration implements Serializable {
     private final String sharedPreferencesName;
     private final int socketTimeout;
     private final boolean logcatFilterByPid;
+    private final boolean nonBlockingReadForLogcat;
     private final boolean sendReportsInDevMode;
 
     private final ImmutableSet<String> excludeMatchingSharedPreferencesKeys;
@@ -149,6 +150,7 @@ public final class ACRAConfiguration implements Serializable {
         sharedPreferencesName = builder.sharedPreferencesName();
         socketTimeout = builder.socketTimeout();
         logcatFilterByPid = builder.logcatFilterByPid();
+        nonBlockingReadForLogcat = builder.nonBlockingReadForLogcat();
         sendReportsInDevMode = builder.sendReportsInDevMode();
         excludeMatchingSharedPreferencesKeys = new ImmutableSet<String>(builder.excludeMatchingSharedPreferencesKeys());
         excludeMatchingSettingsKeys = new ImmutableSet<String>(builder.excludeMatchingSettingsKeys());

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -647,6 +647,18 @@ public final class ConfigurationBuilder {
     }
 
     /**
+     * @param nonBlockingRead true if you want that collecting of logcat lines
+     *                        should not block current thread. Read operation
+     *                        has a timeout of 3 seconds.
+     * @return this instance
+     */
+    @NonNull
+    public ConfigurationBuilder setNonBlockingReadForLogcat(boolean nonBlockingRead) {
+        nonBlockingReadForLogcat = nonBlockingRead;
+        return this;
+    }
+
+    /**
      * @param sendReportsInDevMode false if you want to disable sending reports in development
      *                             mode. Reports will be sent only on signed applications.
      * @return this instance
@@ -1076,6 +1088,13 @@ public final class ConfigurationBuilder {
             return logcatFilterByPid;
         }
         return DEFAULT_LOGCAT_FILTER_BY_PID;
+    }
+
+    boolean nonBlockingReadForLogcat() {
+        if (nonBlockingReadForLogcat != null) {
+            return nonBlockingReadForLogcat;
+        }
+        return DEFAULT_NON_BLOCKING_READ_FOR_LOGCAT;
     }
 
     boolean sendReportsInDevMode() {

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -101,6 +101,7 @@ public final class ConfigurationBuilder {
     private String sharedPreferencesName;
     private Integer socketTimeout;
     private Boolean logcatFilterByPid;
+    private Boolean nonBlockingReadForLogcat;
     private Boolean sendReportsInDevMode;
 
     private String[] excludeMatchingSharedPreferencesKeys;
@@ -166,6 +167,7 @@ public final class ConfigurationBuilder {
             sharedPreferencesName = annotationConfig.sharedPreferencesName();
             socketTimeout = annotationConfig.socketTimeout();
             logcatFilterByPid = annotationConfig.logcatFilterByPid();
+            nonBlockingReadForLogcat = annotationConfig.nonBlockingReadForLogcat();
             sendReportsInDevMode = annotationConfig.sendReportsInDevMode();
             excludeMatchingSharedPreferencesKeys = annotationConfig.excludeMatchingSharedPreferencesKeys();
             excludeMatchingSettingsKeys = annotationConfig.excludeMatchingSettingsKeys();

--- a/src/main/java/org/acra/util/IOUtils.java
+++ b/src/main/java/org/acra/util/IOUtils.java
@@ -131,7 +131,8 @@ public final class IOUtils {
     }
 	
 	/**
-     * Reads an InputStream into a string in an async way
+     * Reads an InputStream into a string in an non blocking way for current thread
+     * It has a default timeout of 3 seconds.
      *
      * @param input  the stream
      * @param filter should return false for lines which should be excluded
@@ -140,7 +141,7 @@ public final class IOUtils {
      * @throws IOException
      */
     @NonNull
-    public static String streamToStringAsync(@NonNull InputStream input, Predicate<String> filter, int limit) throws IOException {
+    public static String streamToStringNonBlockingRead(@NonNull InputStream input, Predicate<String> filter, int limit) throws IOException {
         final BufferedReader reader = new BufferedReader(new InputStreamReader(input), ACRAConstants.DEFAULT_BUFFER_SIZE_IN_BYTES);
         final NonblockingBufferedReader nonBlockingReader = new NonblockingBufferedReader(reader);
         try {

--- a/src/main/java/org/acra/util/IOUtils.java
+++ b/src/main/java/org/acra/util/IOUtils.java
@@ -153,6 +153,8 @@ public final class IOUtils {
                         if (filter.apply(line)) {
                             buffer.add(line);
                         }
+                    } else {
+                    	break;
                     }
                 } catch (InterruptedException e) {}
             }

--- a/src/main/java/org/acra/util/IOUtils.java
+++ b/src/main/java/org/acra/util/IOUtils.java
@@ -143,7 +143,7 @@ public final class IOUtils {
     @NonNull
     public static String streamToStringNonBlockingRead(@NonNull InputStream input, Predicate<String> filter, int limit) throws IOException {
         final BufferedReader reader = new BufferedReader(new InputStreamReader(input), ACRAConstants.DEFAULT_BUFFER_SIZE_IN_BYTES);
-        final NonblockingBufferedReader nonBlockingReader = new NonblockingBufferedReader(reader);
+        final NonBlockingBufferedReader nonBlockingReader = new NonBlockingBufferedReader(reader);
         try {
             String line;
             final List<String> buffer = limit == NO_LIMIT ? new LinkedList<String>() : new BoundedLinkedList<String>(limit);

--- a/src/main/java/org/acra/util/NonBlockingBufferedReader.java
+++ b/src/main/java/org/acra/util/NonBlockingBufferedReader.java
@@ -15,7 +15,7 @@ public class NonBlockingBufferedReader {
     private boolean closed = false;
     private Thread backgroundReaderThread = null;
 
-    public NonblockingBufferedReader(final BufferedReader bufferedReader) {
+    public NonBlockingBufferedReader(final BufferedReader bufferedReader) {
         backgroundReaderThread = new Thread(new Runnable() {
             @Override
             public void run() {

--- a/src/main/java/org/acra/util/NonBlockingBufferedReader.java
+++ b/src/main/java/org/acra/util/NonBlockingBufferedReader.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
  * @author C-Romeo
  * @since 4.9.0
  */
-public class NonblockingBufferedReader {
+public class NonBlockingBufferedReader {
     private final BlockingQueue<String> lines = new LinkedBlockingQueue<String>();
     private boolean closed = false;
     private Thread backgroundReaderThread = null;

--- a/src/main/java/org/acra/util/NonblockingBufferedReader.java
+++ b/src/main/java/org/acra/util/NonblockingBufferedReader.java
@@ -1,0 +1,52 @@
+package org.acra.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author C-Romeo
+ * @since 4.9.0
+ */
+public class NonblockingBufferedReader {
+    private final BlockingQueue<String> lines = new LinkedBlockingQueue<String>();
+    private boolean closed = false;
+    private Thread backgroundReaderThread = null;
+
+    public NonblockingBufferedReader(final BufferedReader bufferedReader) {
+        backgroundReaderThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    while (!Thread.interrupted()) {
+                        String line = bufferedReader.readLine();
+                        if (line == null) {
+                            break;
+                        }
+                        lines.add(line);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    closed = true;
+                    IOUtils.safeClose(bufferedReader);
+                }
+            }
+        });
+        backgroundReaderThread.setDaemon(true);
+        backgroundReaderThread.start();
+    }
+
+    public String readLine() throws InterruptedException {
+        return closed && lines.isEmpty() ? null : lines.poll(500L, TimeUnit.MILLISECONDS);
+    }
+
+    public void close() {
+        if (backgroundReaderThread != null) {
+            backgroundReaderThread.interrupt();
+            backgroundReaderThread = null;
+        }
+    }
+}


### PR DESCRIPTION
I encounter and issue with handleSilentException and ReportField.LOGCAT on Lenovo TAB 2 A8-50F.
It appears that when an ProgressDialog is shown a lot of useless info are spitted to the logs and ACRA spends couple of minutes to receive logs and send report due the fact that reading from InputStream is done in a blocking way.

I think is better to have at least an empty log info than a lots of useless logs due the fact that Stream is blocked for writing.

Also for my particular context handling ACRA's sending exception in another thread helped me, and received some info due the fact ProgressDialog is closed immediately after.
`    	new Thread(new Runnable() {
    		@Override
    		public void run() {
	          	ACRA.getErrorReporter().handleSilentException(e);
    		}
    	}).start();`
[the_culprit.txt](https://github.com/ACRA/acra/files/289759/the_culprit.txt)
