### PR TITLE
Extract DEV_LOGGING conditional to class

### DIFF
--- a/src/main/java/org/acra/ACRA.java
+++ b/src/main/java/org/acra/ACRA.java
@@ -29,7 +29,7 @@ import org.acra.config.ACRAConfigurationException;
 import org.acra.config.ConfigurationBuilder;
 import org.acra.legacy.ReportMigrator;
 import org.acra.log.ACRALog;
-import org.acra.log.AndroidLogDelegate;
+import org.acra.log.DebugConditionalAndroidLog;
 import org.acra.prefs.PrefUtils;
 import org.acra.prefs.SharedPreferencesFactory;
 import org.acra.util.ApplicationStartupProcessor;
@@ -57,7 +57,7 @@ public final class ACRA {
     public static final String LOG_TAG = ACRA.class.getSimpleName();
 
     @NonNull
-    public static ACRALog log = new AndroidLogDelegate();
+    public static ACRALog log = new DebugConditionalAndroidLog();
 
     private static final String ACRA_PRIVATE_PROCESS_NAME= ":acra";
 
@@ -216,7 +216,7 @@ public final class ACRA {
 
         final boolean senderServiceProcess = isACRASenderServiceProcess();
         if (senderServiceProcess) {
-            if (ACRA.DEV_LOGGING) log.d(LOG_TAG, "Not initialising ACRA to listen for uncaught Exceptions as this is the SendWorker process and we only send reports, we don't capture them to avoid infinite loops");
+            log.d(LOG_TAG, "Not initialising ACRA to listen for uncaught Exceptions as this is the SendWorker process and we only send reports, we don't capture them to avoid infinite loops");
         }
 
         final boolean supportedAndroidVersion = Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO;
@@ -307,7 +307,7 @@ public final class ACRA {
      */
     public static boolean isACRASenderServiceProcess() {
         final String processName = getCurrentProcessName();
-        if (ACRA.DEV_LOGGING) log.d(LOG_TAG, "ACRA processName='" + processName + '\'');
+        log.d(LOG_TAG, "ACRA processName='" + processName + '\'');
         //processName sometimes (or always?) starts with the package name, so we use endsWith instead of equals
         return processName != null && processName.endsWith(ACRA_PRIVATE_PROCESS_NAME);
     }

--- a/src/main/java/org/acra/ErrorReporter.java
+++ b/src/main/java/org/acra/ErrorReporter.java
@@ -252,7 +252,7 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler {
 
         try {
             ACRA.log.e(LOG_TAG, "ACRA caught a " + e.getClass().getSimpleName() + " for " + context.getPackageName(), e);
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Building report");
+            ACRA.log.d(LOG_TAG, "Building report");
 
             performDeprecatedReportPriming();
 

--- a/src/main/java/org/acra/builder/LastActivityManager.java
+++ b/src/main/java/org/acra/builder/LastActivityManager.java
@@ -31,7 +31,7 @@ public final class LastActivityManager {
             application.registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
                 @Override
                 public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityCreated " + activity.getClass());
+                    ACRA.log.d(LOG_TAG, "onActivityCreated " + activity.getClass());
                     if (!(activity instanceof BaseCrashReportDialog)) {
                         // Ignore CrashReportDialog because we want the last
                         // application Activity that was started so that we can explicitly kill it off.
@@ -41,22 +41,22 @@ public final class LastActivityManager {
 
                 @Override
                 public void onActivityStarted(@NonNull Activity activity) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityStarted " + activity.getClass());
+                    ACRA.log.d(LOG_TAG, "onActivityStarted " + activity.getClass());
                 }
 
                 @Override
                 public void onActivityResumed(@NonNull Activity activity) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityResumed " + activity.getClass());
+                    ACRA.log.d(LOG_TAG, "onActivityResumed " + activity.getClass());
                 }
 
                 @Override
                 public void onActivityPaused(@NonNull Activity activity) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityPaused " + activity.getClass());
+                    ACRA.log.d(LOG_TAG, "onActivityPaused " + activity.getClass());
                 }
 
                 @Override
                 public void onActivityStopped(@NonNull Activity activity) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityStopped " + activity.getClass());
+                    ACRA.log.d(LOG_TAG, "onActivityStopped " + activity.getClass());
                     synchronized (this){
                         notify();
                     }
@@ -64,12 +64,12 @@ public final class LastActivityManager {
 
                 @Override
                 public void onActivitySaveInstanceState(@NonNull Activity activity, Bundle outState) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivitySaveInstanceState " + activity.getClass());
+                    ACRA.log.d(LOG_TAG, "onActivitySaveInstanceState " + activity.getClass());
                 }
 
                 @Override
                 public void onActivityDestroyed(@NonNull Activity activity) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "onActivityDestroyed " + activity.getClass());
+                    ACRA.log.d(LOG_TAG, "onActivityDestroyed " + activity.getClass());
                 }
             });
         }

--- a/src/main/java/org/acra/builder/ReportExecutor.java
+++ b/src/main/java/org/acra/builder/ReportExecutor.java
@@ -188,7 +188,7 @@ public final class ReportExecutor {
             }
 
         } else if (reportingInteractionMode == ReportingInteractionMode.NOTIFICATION) {
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Creating Notification.");
+            ACRA.log.d(LOG_TAG, "Creating Notification.");
             createNotification(reportFile, reportBuilder);
         }
 
@@ -201,7 +201,6 @@ public final class ReportExecutor {
 
                 @Override
                 public void run() {
-                    if (ACRA.DEV_LOGGING)
                         ACRA.log.d(LOG_TAG, "Waiting for " + ACRAConstants.TOAST_WAIT_DURATION
                                 + " millis from " + sentToastTimeMillis.initialTimeMillis
                                 + " currentMillis=" + System.currentTimeMillis());
@@ -210,10 +209,9 @@ public final class ReportExecutor {
                         // Wait a bit to let the user read the toast
                         if (sleep > 0L) Thread.sleep(sleep);
                     } catch (InterruptedException e1) {
-                        if (ACRA.DEV_LOGGING)
                             ACRA.log.d(LOG_TAG, "Interrupted while waiting for Toast to end.", e1);
                     }
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Finished waiting for Toast");
+                    ACRA.log.d(LOG_TAG, "Finished waiting for Toast");
                     dialogAndEnd(reportBuilder, reportFile, showDirectDialog);
                 }
             }.start();
@@ -227,13 +225,13 @@ public final class ReportExecutor {
             // Create a new activity task with the confirmation dialog.
             // This new task will be persisted on application restart
             // right after its death.
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Creating CrashReportDialog for " + reportFile);
+            ACRA.log.d(LOG_TAG, "Creating CrashReportDialog for " + reportFile);
             final Intent dialogIntent = createCrashReportDialogIntent(reportFile, reportBuilder);
             dialogIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(dialogIntent);
         }
 
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Wait for Toast + worker ended. Kill Application ? " + reportBuilder.isEndApplication());
+        ACRA.log.d(LOG_TAG, "Wait for Toast + worker ended. Kill Application ? " + reportBuilder.isEndApplication());
 
         if (reportBuilder.isEndApplication()) {
             endApplication(reportBuilder.getUncaughtExceptionThread(), reportBuilder.getException());
@@ -249,7 +247,7 @@ public final class ReportExecutor {
         final boolean handlingUncaughtException = uncaughtExceptionThread != null;
         if (handlingUncaughtException && letDefaultHandlerEndApplication && defaultExceptionHandler != null) {
             // Let the system default handler do it's job and display the force close dialog.
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Handing Exception on to default ExceptionHandler");
+            ACRA.log.d(LOG_TAG, "Handing Exception on to default ExceptionHandler");
             defaultExceptionHandler.uncaughtException(uncaughtExceptionThread, th);
         } else {
             // If ACRA handles user notifications with a Toast or a Notification
@@ -261,12 +259,12 @@ public final class ReportExecutor {
             // it. Activity#finish (and maybe it's parent too).
             final Activity lastActivity = lastActivityManager.getLastActivity();
             if (lastActivity != null) {
-                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Finishing the last Activity prior to killing the Process");
+                ACRA.log.d(LOG_TAG, "Finishing the last Activity prior to killing the Process");
                 lastActivity.runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
                         lastActivity.finish();
-                        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Finished " + lastActivity.getClass());
+                        ACRA.log.d(LOG_TAG, "Finished " + lastActivity.getClass());
                     }
                 });
 
@@ -314,7 +312,7 @@ public final class ReportExecutor {
         final CharSequence tickerText = context.getText(config.resNotifTickerText());
         final long when = System.currentTimeMillis();
 
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Creating Notification for " + reportFile);
+        ACRA.log.d(LOG_TAG, "Creating Notification for " + reportFile);
         final Intent crashReportDialogIntent = createCrashReportDialogIntent(reportFile, reportBuilder);
         final PendingIntent contentIntent = PendingIntent.getActivity(context, mNotificationCounter++, crashReportDialogIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
@@ -373,7 +371,7 @@ public final class ReportExecutor {
      */
     private void saveCrashReportFile(@NonNull File file, @NonNull CrashReportData crashData) {
         try {
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Writing crash report file " + file);
+            ACRA.log.d(LOG_TAG, "Writing crash report file " + file);
             final CrashReportPersister persister = new CrashReportPersister();
             persister.store(crashData, file);
         } catch (Exception e) {
@@ -390,7 +388,7 @@ public final class ReportExecutor {
      */
     @NonNull
     private Intent createCrashReportDialogIntent(@NonNull File reportFile, @NonNull ReportBuilder reportBuilder) {
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Creating DialogIntent for " + reportFile + " exception=" + reportBuilder.getException());
+        ACRA.log.d(LOG_TAG, "Creating DialogIntent for " + reportFile + " exception=" + reportBuilder.getException());
         final Intent dialogIntent = new Intent(context, config.reportDialogClass());
         dialogIntent.putExtra(ACRAConstants.EXTRA_REPORT_FILE, reportFile);
         dialogIntent.putExtra(ACRAConstants.EXTRA_REPORT_EXCEPTION, reportBuilder.getException());

--- a/src/main/java/org/acra/collector/CrashReportDataFactory.java
+++ b/src/main/java/org/acra/collector/CrashReportDataFactory.java
@@ -190,7 +190,6 @@ public final class CrashReportDataFactory {
             // Though, we can call logcat without any permission and still get traces related to our app.
             final boolean hasReadLogsPermission = pm.hasPermission(Manifest.permission.READ_LOGS) || Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
             if (prefs.getBoolean(ACRA.PREF_ENABLE_SYSTEM_LOGS, true) && hasReadLogsPermission) {
-                if (ACRA.DEV_LOGGING)
                     ACRA.log.d(LOG_TAG, "READ_LOGS granted! ACRA can include LogCat and DropBox data.");
                 final LogCatCollector logCatCollector = new LogCatCollector();
                 if (crashReportFields.contains(LOGCAT)) {
@@ -222,7 +221,6 @@ public final class CrashReportDataFactory {
                     }
                 }
             } else {
-                if (ACRA.DEV_LOGGING)
                     ACRA.log.d(LOG_TAG, "READ_LOGS not allowed. ACRA will not include LogCat and DropBox data.");
             }
 

--- a/src/main/java/org/acra/collector/DropBoxCollector.java
+++ b/src/main/java/org/acra/collector/DropBoxCollector.java
@@ -107,7 +107,7 @@ final class DropBoxCollector {
             return dropboxContent.toString();
 
         } catch (Exception e) {
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "DropBoxManager not available.");
+            ACRA.log.d(LOG_TAG, "DropBoxManager not available.");
         }
 
         return NO_RESULT;

--- a/src/main/java/org/acra/collector/LogCatCollector.java
+++ b/src/main/java/org/acra/collector/LogCatCollector.java
@@ -99,7 +99,7 @@ class LogCatCollector {
         try {
             final Process process = Runtime.getRuntime().exec(commandLine.toArray(new String[commandLine.size()]));
 
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Retrieving logcat output...");
+            ACRA.log.d(LOG_TAG, "Retrieving logcat output...");
 
             // Dump stderr to null
             new Thread(new Runnable() {

--- a/src/main/java/org/acra/collector/SharedPreferencesCollector.java
+++ b/src/main/java/org/acra/collector/SharedPreferencesCollector.java
@@ -82,7 +82,7 @@ final class SharedPreferencesCollector {
             // Add all non-filtered preferences from that preference file.
             for (final Map.Entry<String, ?> prefEntry : prefEntries.entrySet()) {
                 if (filteredKey(prefEntry.getKey())) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Filtered out sharedPreference=" + sharedPrefId + "  key=" + prefEntry.getKey() + " due to filtering rule");
+                    ACRA.log.d(LOG_TAG, "Filtered out sharedPreference=" + sharedPrefId + "  key=" + prefEntry.getKey() + " due to filtering rule");
                 } else {
                     final Object prefValue = prefEntry.getValue();
                     result.append(sharedPrefId).append('.').append(prefEntry.getKey()).append('=');

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -840,13 +840,13 @@ public final class ConfigurationBuilder {
     Set<ReportField> reportContent() {
         final Set<ReportField> reportContent = new HashSet<ReportField>();
         if (customReportContent != null && customReportContent.length != 0) {
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Using custom Report Fields");
+            ACRA.log.d(LOG_TAG, "Using custom Report Fields");
             reportContent.addAll(Arrays.asList(customReportContent));
         } else if (mailTo == null || DEFAULT_STRING_VALUE.equals(mailTo)) {
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Using default Report Fields");
+            ACRA.log.d(LOG_TAG, "Using default Report Fields");
             reportContent.addAll(Arrays.asList(DEFAULT_REPORT_FIELDS));
         } else {
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Using default Mail Report Fields");
+            ACRA.log.d(LOG_TAG, "Using default Mail Report Fields");
             reportContent.addAll(Arrays.asList(DEFAULT_MAIL_REPORT_FIELDS));
         }
 

--- a/src/main/java/org/acra/dialog/BaseCrashReportDialog.java
+++ b/src/main/java/org/acra/dialog/BaseCrashReportDialog.java
@@ -57,10 +57,7 @@ public abstract class BaseCrashReportDialog extends Activity {
     protected final void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-
-        if (ACRA.DEV_LOGGING) {
             ACRA.log.d(LOG_TAG, "CrashReportDialog extras=" + getIntent().getExtras());
-        }
 
         final Serializable sConfig = getIntent().getSerializableExtra(ACRAConstants.EXTRA_REPORT_CONFIG);
         final Serializable sReportFile = getIntent().getSerializableExtra(ACRAConstants.EXTRA_REPORT_FILE);
@@ -68,7 +65,7 @@ public abstract class BaseCrashReportDialog extends Activity {
         final boolean forceCancel = getIntent().getBooleanExtra(ACRAConstants.EXTRA_FORCE_CANCEL, false);
 
         if (forceCancel) {
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Forced reports deletion.");
+            ACRA.log.d(LOG_TAG, "Forced reports deletion.");
             cancelReports();
             finish();
         } else if ((sConfig instanceof ACRAConfiguration) && (sReportFile instanceof File) && ((sException instanceof Throwable) || sException == null)) {
@@ -110,7 +107,7 @@ public abstract class BaseCrashReportDialog extends Activity {
     protected final void sendCrash(@Nullable String comment, @Nullable String userEmail) {
         final CrashReportPersister persister = new CrashReportPersister();
         try {
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Add user comment to " + reportFile);
+            ACRA.log.d(LOG_TAG, "Add user comment to " + reportFile);
             final CrashReportData crashData = persister.load(reportFile);
             crashData.put(USER_COMMENT, comment == null ? "" : comment);
             crashData.put(USER_EMAIL, userEmail == null ? "" : userEmail);

--- a/src/main/java/org/acra/legacy/ReportMigrator.java
+++ b/src/main/java/org/acra/legacy/ReportMigrator.java
@@ -38,11 +38,11 @@ public final class ReportMigrator {
             final String fileName = file.getName();
             if (fileNameParser.isApproved(fileName)) {
                 if (file.renameTo(new File(reportLocator.getApprovedFolder(), fileName))) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Cold not migrate unsent ACRA crash report : " + fileName);
+                    ACRA.log.d(LOG_TAG, "Cold not migrate unsent ACRA crash report : " + fileName);
                 }
             } else {
                 if (file.renameTo(new File(reportLocator.getUnapprovedFolder(), fileName))) {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Cold not migrate unsent ACRA crash report : " + fileName);
+                    ACRA.log.d(LOG_TAG, "Cold not migrate unsent ACRA crash report : " + fileName);
                 }
             }
         }
@@ -62,7 +62,7 @@ public final class ReportMigrator {
             return new File[0];
         }
 
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Looking for error files in " + dir.getAbsolutePath());
+        ACRA.log.d(LOG_TAG, "Looking for error files in " + dir.getAbsolutePath());
 
         // Filter for ".stacktrace" files
         final FilenameFilter filter = new FilenameFilter() {

--- a/src/main/java/org/acra/log/AndroidLogDelegate.java
+++ b/src/main/java/org/acra/log/AndroidLogDelegate.java
@@ -9,7 +9,7 @@ import android.util.Log;
  * @author William Ferguson
  * @since 4.3.0
  */
-public final class AndroidLogDelegate implements ACRALog {
+public class AndroidLogDelegate implements ACRALog {
     @Override
     public int v(String tag, String msg) {
         return Log.v(tag, msg);

--- a/src/main/java/org/acra/log/DebugConditionalAndroidLog.java
+++ b/src/main/java/org/acra/log/DebugConditionalAndroidLog.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2016
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acra.log;
+
+import org.acra.ACRA;
+
+/**
+ * Logs debug and verbose messages only if {@link ACRA#DEV_LOGGING} is true
+ *
+ * @author F43nd1r
+ * @since 4.9.1
+ */
+public class DebugConditionalAndroidLog extends AndroidLogDelegate {
+    @Override
+    public int v(String tag, String msg) {
+        if (ACRA.DEV_LOGGING) {
+            return super.v(tag, msg);
+        }
+        return 0;
+    }
+
+    @Override
+    public int v(String tag, String msg, Throwable tr) {
+        if (ACRA.DEV_LOGGING) {
+            return super.v(tag, msg, tr);
+        }
+        return 0;
+    }
+
+    @Override
+    public int d(String tag, String msg) {
+        if (ACRA.DEV_LOGGING) {
+            return super.d(tag, msg);
+        }
+        return 0;
+    }
+
+    @Override
+    public int d(String tag, String msg, Throwable tr) {
+        if (ACRA.DEV_LOGGING) {
+            return super.d(tag, msg, tr);
+        }
+        return 0;
+    }
+}

--- a/src/main/java/org/acra/sender/DefaultReportSenderFactory.java
+++ b/src/main/java/org/acra/sender/DefaultReportSenderFactory.java
@@ -40,7 +40,7 @@ public final class DefaultReportSenderFactory implements ReportSenderFactory {
             return new NullSender();
         } else if (config.formUri() != null && !"".equals(config.formUri())) {
             // If formUri is set, instantiate a sender for a generic HTTP POST form with default mapping.
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, context.getPackageName() + " reports will be sent by Http.");
+            ACRA.log.d(LOG_TAG, context.getPackageName() + " reports will be sent by Http.");
             return new HttpSenderFactory().create(context, config);
         } else {
             return new NullSender();

--- a/src/main/java/org/acra/sender/HttpSender.java
+++ b/src/main/java/org/acra/sender/HttpSender.java
@@ -197,7 +197,7 @@ public class HttpSender implements ReportSender {
 
         try {
             URL reportUrl = mFormUri == null ? new URL(config.formUri()) : new URL(mFormUri.toString());
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Connect to " + reportUrl.toString());
+            ACRA.log.d(LOG_TAG, "Connect to " + reportUrl.toString());
 
             final String login = mUsername != null ? mUsername : isNull(config.formUriBasicAuthLogin()) ? null : config.formUriBasicAuthLogin();
             final String password = mPassword != null ? mPassword : isNull(config.formUriBasicAuthPassword()) ? null : config.formUriBasicAuthPassword();

--- a/src/main/java/org/acra/sender/ReportDistributor.java
+++ b/src/main/java/org/acra/sender/ReportDistributor.java
@@ -98,16 +98,16 @@ final class ReportDistributor {
             final List<RetryPolicy.FailedSender> failedSenders = new LinkedList<RetryPolicy.FailedSender>();
             for (ReportSender sender : reportSenders) {
                 try {
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Sending report using " + sender.getClass().getName());
+                    ACRA.log.d(LOG_TAG, "Sending report using " + sender.getClass().getName());
                     sender.send(context, errorContent);
-                    if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Sent report using " + sender.getClass().getName());
+                    ACRA.log.d(LOG_TAG, "Sent report using " + sender.getClass().getName());
                 } catch (ReportSenderException e) {
                     failedSenders.add(new RetryPolicy.FailedSender(sender, e));
                 }
             }
 
             if (failedSenders.isEmpty()) {
-                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Report was sent by all senders");
+                ACRA.log.d(LOG_TAG, "Report was sent by all senders");
             } else if (getRetryPolicy().shouldRetrySend(reportSenders, failedSenders)) {
                 final Throwable firstFailure = failedSenders.get(0).getException();
                 throw new ReportSenderException("Policy marked this task as incomplete. ACRA will try to send this report again.", firstFailure);

--- a/src/main/java/org/acra/sender/SenderService.java
+++ b/src/main/java/org/acra/sender/SenderService.java
@@ -40,7 +40,7 @@ public class SenderService extends IntentService {
 
         final ACRAConfiguration config = (ACRAConfiguration) intent.getSerializableExtra(EXTRA_ACRA_CONFIG);
 
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "About to start sending reports from SenderService");
+        ACRA.log.d(LOG_TAG, "About to start sending reports from SenderService");
         try {
             final List<ReportSender> senderInstances = getSenderInstances(config, senderFactoryClasses);
 
@@ -73,7 +73,7 @@ public class SenderService extends IntentService {
             ACRA.log.e(LOG_TAG, "", e);
         }
 
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Finished sending reports from SenderService");
+        ACRA.log.d(LOG_TAG, "Finished sending reports from SenderService");
     }
 
     @NonNull
@@ -97,7 +97,7 @@ public class SenderService extends IntentService {
      * Flag all pending reports as "approved" by the user. These reports can be sent.
      */
     private void markReportsAsApproved() {
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Mark all pending reports as approved.");
+        ACRA.log.d(LOG_TAG, "Mark all pending reports as approved.");
 
         for (File report : locator.getUnapprovedReports()) {
             final File approvedReport = new File(locator.getApprovedFolder(), report.getName());

--- a/src/main/java/org/acra/sender/SenderServiceStarter.java
+++ b/src/main/java/org/acra/sender/SenderServiceStarter.java
@@ -31,7 +31,7 @@ public class SenderServiceStarter {
      * @param approveReportsFirst   If true then approve unapproved reports first.
      */
     public void startService(boolean onlySendSilentReports, boolean approveReportsFirst) {
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "About to start SenderService");
+        ACRA.log.d(LOG_TAG, "About to start SenderService");
         final Intent intent = new Intent(context, SenderService.class);
         intent.putExtra(SenderService.EXTRA_ONLY_SEND_SILENT_REPORTS, onlySendSilentReports);
         intent.putExtra(SenderService.EXTRA_APPROVE_REPORTS_FIRST, approveReportsFirst);

--- a/src/main/java/org/acra/util/HttpRequest.java
+++ b/src/main/java/org/acra/util/HttpRequest.java
@@ -152,12 +152,11 @@ public final class HttpRequest {
             IOUtils.safeClose(outputStream);
         }
 
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Sending request to " + url);
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Http " + method.name() + " content : ");
-        if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, content);
+        ACRA.log.d(LOG_TAG, "Sending request to " + url);
+        ACRA.log.d(LOG_TAG, "Http " + method.name() + " content : ");
+        ACRA.log.d(LOG_TAG, content);
 
         final int responseCode = urlConnection.getResponseCode();
-        if (ACRA.DEV_LOGGING)
             ACRA.log.d(LOG_TAG, "Request response : " + responseCode + " : " + urlConnection.getResponseMessage());
         if ((responseCode >= HTTP_SUCCESS) && (responseCode < HTTP_REDIRECT)) {
             // All is good


### PR DESCRIPTION
As we always have the same check before `log.d` this simplifies the code considerably. It also allows custom Log classes to decide themselves if the want to swallow debug logs.