### PR TITLE
ServiceHelper

### DIFF
--- a/src/main/java/org/acra/builder/ReportExecutor.java
+++ b/src/main/java/org/acra/builder/ReportExecutor.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -24,6 +25,7 @@ import org.acra.file.CrashReportPersister;
 import org.acra.file.ReportLocator;
 import org.acra.prefs.SharedPreferencesFactory;
 import org.acra.sender.SenderServiceStarter;
+import org.acra.service.ServiceHelper;
 import org.acra.util.ToastSender;
 
 import java.io.File;
@@ -259,6 +261,12 @@ public final class ReportExecutor {
             // Trying to solve https://github.com/ACRA/acra/issues/42#issuecomment-12134144
             // Determine the current/last Activity that was started and close
             // it. Activity#finish (and maybe it's parent too).
+            final Class<? extends Service> service = ServiceHelper.getOwner(uncaughtExceptionThread);
+            ACRA.log.d(LOG_TAG, "Service is " + (service != null ? service.getName() : "null"));
+            if (service != null) {
+                if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Stopping owner service of the crashed thread: " + service.getName());
+                context.stopService(new Intent(context, service));
+            }
             final Activity lastActivity = lastActivityManager.getLastActivity();
             if (lastActivity != null) {
                 if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Finishing the last Activity prior to killing the Process");

--- a/src/main/java/org/acra/service/ServiceHelper.java
+++ b/src/main/java/org/acra/service/ServiceHelper.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2016
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acra.service;
+
+import android.app.Service;
+import android.support.annotation.Nullable;
+
+import java.util.WeakHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Helps to prevent infinite Service restarts
+ *
+ * @author F43nd1r
+ * @since 4.9.1
+ */
+public final class ServiceHelper {
+
+    private static final WeakHashMap<Thread, Class<? extends Service>> map = new WeakHashMap<Thread, Class<? extends Service>>();
+
+    private final Class<? extends Service> service;
+
+    public ServiceHelper(Class<? extends Service> service) {
+        this.service = service;
+    }
+
+    public ThreadPoolExecutor getNewExecutor() {
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>());
+        executor.setThreadFactory(new RegisteredThreadFactory());
+        return executor;
+    }
+
+    public void registerThread(Thread thread) {
+        map.put(thread, service);
+    }
+
+    @Nullable
+    public static Class<? extends Service> getOwner(Thread thread){
+        return map.get(thread);
+    }
+
+    private class RegisteredThreadFactory implements ThreadFactory {
+        private ThreadFactory delegate = Executors.defaultThreadFactory();
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = delegate.newThread(r);
+            registerThread(thread);
+            return thread;
+        }
+    }
+}

--- a/src/main/java/org/acra/service/ServiceHelper.java
+++ b/src/main/java/org/acra/service/ServiceHelper.java
@@ -37,10 +37,18 @@ public final class ServiceHelper {
 
     private final Class<? extends Service> service;
 
+    /**
+     * Create a new ServiceHelper for the specified service
+     *
+     * @param service the service which owns all threads registered in this ServiceHelper
+     */
     public ServiceHelper(Class<? extends Service> service) {
         this.service = service;
     }
 
+    /**
+     * @return a new ThreadPoolExecutor which automatically registers its Threads
+     */
     public ThreadPoolExecutor getNewExecutor() {
         ThreadPoolExecutor executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
                 60L, TimeUnit.SECONDS,
@@ -49,12 +57,21 @@ public final class ServiceHelper {
         return executor;
     }
 
+    /**
+     * register a thread for this service
+     *
+     * @param thread the thread to register
+     */
     public void registerThread(Thread thread) {
         map.put(thread, service);
     }
 
+    /**
+     * @param thread a thread
+     * @return the owner class of the thread if known. null otherwise.
+     */
     @Nullable
-    public static Class<? extends Service> getOwner(Thread thread){
+    public static Class<? extends Service> getOwner(Thread thread) {
         return map.get(thread);
     }
 


### PR DESCRIPTION
So this is my solution for #477 . The downside is: The user has to register every single `Thread` he creates inside the `Service` (or use the provided `ThreadPoolExecutor`).