### PR TITLE
ApplicationLogFileDir

### DIFF
--- a/src/main/java/org/acra/annotation/ReportsCrashes.java
+++ b/src/main/java/org/acra/annotation/ReportsCrashes.java
@@ -34,6 +34,7 @@ import org.acra.config.DefaultRetryPolicy;
 import org.acra.config.RetryPolicy;
 import org.acra.dialog.BaseCrashReportDialog;
 import org.acra.dialog.CrashReportDialog;
+import org.acra.file.Directory;
 import org.acra.security.KeyStoreFactory;
 import org.acra.security.NoKeyStoreFactory;
 import org.acra.sender.DefaultReportSenderFactory;
@@ -552,6 +553,14 @@ public @interface ReportsCrashes {
      * @return number of lines to collect.
      */
     int applicationLogFileLines() default ACRAConstants.DEFAULT_APPLICATION_LOGFILE_LINES;
+
+    /**
+     * To use in combination with {@link ReportField#APPLICATION_LOG} to set the root
+     * for the path provided in {@link #applicationLogFile()}
+     *
+     * @return the directory of the application log file
+     */
+    @NonNull Directory applicationLogFileDir() default Directory.FILES_LEGACY;
 
     /**
      * @return Class for the CrashReportDialog used when prompting the user for crash details.

--- a/src/main/java/org/acra/collector/CrashReportDataFactory.java
+++ b/src/main/java/org/acra/collector/CrashReportDataFactory.java
@@ -500,7 +500,7 @@ public final class CrashReportDataFactory {
             // Application specific log file
             if (crashReportFields.contains(APPLICATION_LOG)) {
                 try {
-                    final String logFile = new LogFileCollector().collectLogFile(context, config.applicationLogFile(), config.applicationLogFileLines());
+                    final String logFile = new LogFileCollector().collectLogFile(context, config.applicationLogFileDir(), config.applicationLogFile(), config.applicationLogFileLines());
                     crashReportData.put(APPLICATION_LOG, logFile);
                 } catch (IOException e) {
                     ACRA.log.e(LOG_TAG, "Error while reading application log file " + config.applicationLogFile(), e);

--- a/src/main/java/org/acra/config/ACRAConfiguration.java
+++ b/src/main/java/org/acra/config/ACRAConfiguration.java
@@ -27,6 +27,7 @@ import org.acra.ReportingInteractionMode;
 import org.acra.builder.ReportPrimer;
 import org.acra.collections.ImmutableList;
 import org.acra.dialog.BaseCrashReportDialog;
+import org.acra.file.Directory;
 import org.acra.security.KeyStoreFactory;
 import org.acra.sender.HttpSender.Method;
 import org.acra.sender.HttpSender.Type;
@@ -101,6 +102,7 @@ public final class ACRAConfiguration implements Serializable {
     private final Class buildConfigClass;
     private final String applicationLogFile;
     private final int applicationLogFileLines;
+    private final Directory applicationLogFileDir;
 
     private final Method httpMethod;
     private final Type reportType;
@@ -156,6 +158,7 @@ public final class ACRAConfiguration implements Serializable {
         buildConfigClass = builder.buildConfigClass();
         applicationLogFile = builder.applicationLogFile();
         applicationLogFileLines = builder.applicationLogFileLines();
+        applicationLogFileDir = builder.applicationLogFileDir();
         reportDialogClass = builder.reportDialogClass();
         reportPrimerClass = builder.reportPrimerClass();
         httpMethod = builder.httpMethod();
@@ -372,6 +375,11 @@ public final class ACRAConfiguration implements Serializable {
 
     public int applicationLogFileLines() {
         return applicationLogFileLines;
+    }
+
+    @NonNull
+    public Directory applicationLogFileDir() {
+        return applicationLogFileDir;
     }
 
     @NonNull

--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -31,6 +31,7 @@ import org.acra.builder.NoOpReportPrimer;
 import org.acra.builder.ReportPrimer;
 import org.acra.dialog.BaseCrashReportDialog;
 import org.acra.dialog.CrashReportDialog;
+import org.acra.file.Directory;
 import org.acra.security.KeyStoreFactory;
 import org.acra.security.NoKeyStoreFactory;
 import org.acra.sender.DefaultReportSenderFactory;
@@ -108,6 +109,7 @@ public final class ConfigurationBuilder {
     private Class buildConfigClass;
     private String applicationLogFile;
     private Integer applicationLogFileLines;
+    private Directory applicationLogFileDir;
 
     private Method httpMethod;
     private Type reportType;
@@ -173,6 +175,7 @@ public final class ConfigurationBuilder {
             buildConfigClass = annotationConfig.buildConfigClass();
             applicationLogFile = annotationConfig.applicationLogFile();
             applicationLogFileLines = annotationConfig.applicationLogFileLines();
+            applicationLogFileDir = annotationConfig.applicationLogFileDir();
             reportDialogClass = annotationConfig.reportDialogClass();
             reportPrimerClass = annotationConfig.reportPrimerClass();
             httpMethod = annotationConfig.httpMethod();
@@ -723,6 +726,18 @@ public final class ConfigurationBuilder {
     }
 
     /**
+     * @param directory The directory in which the application log file will be searched,
+     *                                to be used with {@link ReportField#APPLICATION_LOG} and
+     *                                {@link ReportsCrashes#applicationLogFile()}
+     * @return this instance
+     */
+    @NonNull
+    public ConfigurationBuilder setApplicationLogFileDir(@NonNull Directory directory){
+        this.applicationLogFileDir = directory;
+        return this;
+    }
+
+    /**
      * @param httpMethod The method to be used to send data to the server.
      * @return this instance
      */
@@ -1134,6 +1149,14 @@ public final class ConfigurationBuilder {
             return applicationLogFileLines;
         }
         return DEFAULT_APPLICATION_LOGFILE_LINES;
+    }
+
+    @NonNull
+    Directory applicationLogFileDir() {
+        if(applicationLogFileDir != null){
+            return applicationLogFileDir;
+        }
+        return Directory.FILES_LEGACY;
     }
 
     @NonNull

--- a/src/main/java/org/acra/file/Directory.java
+++ b/src/main/java/org/acra/file/Directory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acra.file;
+
+import android.content.Context;
+import android.os.Environment;
+
+/**
+ * @author F43nd1r
+ * @since 31.08.2016
+ */
+public enum Directory {
+    /**
+     * Legacy behaviour:
+     * If the string starts with a path separator, this behaves like {@link #ROOT}.
+     * Otherwise it behaves like {@link #FILES}.
+     */
+    FILES_LEGACY,
+    /**
+     * Directory returned by {@link Context#getFilesDir()}
+     */
+    FILES,
+    /**
+     * Directory returned by {@link Context#getExternalFilesDir(String)}
+     */
+    EXTERNAL_FILES,
+    /**
+     * Directory returned by {@link Context#getCacheDir()}
+     */
+    CACHE,
+    /**
+     * Directory returned by {@link Context#getExternalCacheDir()}
+     */
+    EXTERNAL_CACHE,
+    /**
+     * Directory returned by {@link Context#getNoBackupFilesDir()}
+     * Will fall back to {@link Context#getFilesDir()} on API < 21
+     */
+    NO_BACKUP_FILES,
+    /**
+     * Directory returned by {@link Environment#getExternalStorageDirectory()}
+     */
+    EXTERNAL_STORAGE,
+    /**
+     * Root Directory, paths in this directory are absolute paths
+     */
+    ROOT
+}


### PR DESCRIPTION
Android paths are becoming more and more relative. This provides a way to specify a relative log file path not only in the files directory.
This is fully backwards compatible (as the default FILES_LEGACY behaves as the old code).