### PR TITLE
Use compat classes where appropriate, use PrefUtils instead of commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 			we need to compile against version 23. All such classes are in the org.acra.jraf package.
 		-->
         <android.version>23</android.version>
-		<support.version>23.3.0</support.version>
+		<support.version>24.1.1</support.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/acra/collector/DisplayManagerCollector.java
+++ b/src/main/java/org/acra/collector/DisplayManagerCollector.java
@@ -18,14 +18,13 @@ package org.acra.collector;
 import android.content.Context;
 import android.graphics.Point;
 import android.graphics.Rect;
-import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.v4.hardware.display.DisplayManagerCompat;
 import android.util.DisplayMetrics;
 import android.util.SparseArray;
 import android.view.Display;
 import android.view.Surface;
-import android.view.WindowManager;
 
 import org.acra.ReportField;
 import org.acra.builder.ReportBuilder;
@@ -48,23 +47,8 @@ final class DisplayManagerCollector extends Collector {
     @NonNull
     @Override
     String collect(ReportField reportField, ReportBuilder reportBuilder) {
-        final Display[] displays;
         final StringBuilder result = new StringBuilder();
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            // Before Android 4.2, there was a single display available from the
-            // window manager
-            final WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-            displays = new Display[1];
-            displays[0] = windowManager.getDefaultDisplay();
-        } else {
-            // Since Android 4.2, we can fetch multiple displays with the
-            // DisplayManager.
-            final DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
-            displays = displayManager.getDisplays();
-        }
-
-        for (Display display : displays) {
+        for (Display display : DisplayManagerCompat.getInstance(context).getDisplays()) {
             result.append(collectDisplayData(display));
         }
 

--- a/src/main/java/org/acra/collector/LogCatCollector.java
+++ b/src/main/java/org/acra/collector/LogCatCollector.java
@@ -89,11 +89,6 @@ final class LogCatCollector extends Collector {
         final int tailIndex = logcatArgumentsList.indexOf("-t");
         if (tailIndex > -1 && tailIndex < logcatArgumentsList.size()) {
             tailCount = Integer.parseInt(logcatArgumentsList.get(tailIndex + 1));
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.FROYO) {
-                logcatArgumentsList.remove(tailIndex + 1);
-                logcatArgumentsList.remove(tailIndex);
-                logcatArgumentsList.add("-d");
-            }
         } else {
             tailCount = -1;
         }

--- a/src/main/java/org/acra/collector/LogFileCollector.java
+++ b/src/main/java/org/acra/collector/LogFileCollector.java
@@ -18,19 +18,23 @@ package org.acra.collector;
 
 import android.app.Application;
 import android.content.Context;
-import android.os.Build;
 import android.os.Environment;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 
 import org.acra.ACRA;
-import org.acra.file.Directory;
 import org.acra.ACRAConstants;
 import org.acra.ReportField;
 import org.acra.builder.ReportBuilder;
 import org.acra.config.ACRAConfiguration;
+import org.acra.file.Directory;
 import org.acra.util.IOUtils;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 import static org.acra.ACRA.LOG_TAG;
 
@@ -94,11 +98,7 @@ final class LogFileCollector extends Collector {
                 dir = context.getExternalCacheDir();
                 break;
             case NO_BACKUP_FILES:
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    dir = context.getNoBackupFilesDir();
-                } else {
-                    dir = context.getFilesDir();
-                }
+                dir = ContextCompat.getNoBackupFilesDir(context);
                 break;
             case EXTERNAL_STORAGE:
                 dir = Environment.getExternalStorageDirectory();

--- a/src/main/java/org/acra/dialog/CrashReportDialog.java
+++ b/src/main/java/org/acra/dialog/CrashReportDialog.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 
 import org.acra.ACRA;
 import org.acra.ACRAConstants;
+import org.acra.prefs.PrefUtils;
 import org.acra.prefs.SharedPreferencesFactory;
 
 
@@ -220,7 +221,7 @@ public class CrashReportDialog extends BaseCrashReportDialog implements DialogIn
                 userEmail = userEmailView.getText().toString();
                 final SharedPreferences.Editor prefEditor = prefs.edit();
                 prefEditor.putString(ACRA.PREF_USER_EMAIL_ADDRESS, userEmail);
-                prefEditor.commit();
+                PrefUtils.save(prefEditor);
             } else {
                 userEmail = prefs.getString(ACRA.PREF_USER_EMAIL_ADDRESS, "");
             }


### PR DESCRIPTION
Note: Support library version update was required for ContextCompat.getNoBackupFilesDir.
Note2: The removed condition was always false, as the minimum supported version is FROYO.

Note3: I did not use the newest support library version (24.2.0), because it has minSdk 9. At some point we should follow that, but right now it is not necessary (altough we could reduce the aar size with it, as 24.2.0 is modularized. see https://developer.android.com/topic/libraries/support-library/revisions.html).