### PR TITLE
Remove BuildConfig from validated classes

### DIFF
--- a/src/main/java/org/acra/config/ConfigurationBuilder.java
+++ b/src/main/java/org/acra/config/ConfigurationBuilder.java
@@ -234,7 +234,7 @@ public final class ConfigurationBuilder {
             throw new ACRAConfigurationException("Report sender factories: using no report senders will make ACRA useless. Configure at least one ReportSenderFactory.");
         }
         checkValidity((Class[]) reportSenderFactoryClasses());
-        checkValidity(reportDialogClass(), reportPrimerClass(), retryPolicyClass(), keyStoreFactoryClass(), buildConfigClass());
+        checkValidity(reportDialogClass(), reportPrimerClass(), retryPolicyClass(), keyStoreFactoryClass());
 
         return new ACRAConfiguration(this);
     }


### PR DESCRIPTION
BuildConfig class does not have to be instantiatable and thus should not be checked for that.
Resolves a rare issue where proguard made the constructor of that class private.
