### PR TITLE
Newlines in custom data are shown as \n in emails

### DIFF
--- a/src/main/java/org/acra/sender/EmailIntentSender.java
+++ b/src/main/java/org/acra/sender/EmailIntentSender.java
@@ -66,8 +66,12 @@ public class EmailIntentSender implements ReportSender {
 
         final StringBuilder builder = new StringBuilder();
         for (ReportField field : fields) {
+            String value = errorContent.get(field);
+            if (value != null) {
+                value = value.replaceAll("\\\\n","\n");
+            }
             builder.append(field.toString()).append('=');
-            builder.append(errorContent.get(field));
+            builder.append(value);
             builder.append('\n');
         }
         return builder.toString();


### PR DESCRIPTION
Newlines are escaped in [CustomDataCollector](https://github.com/ACRA/acra/blob/master/src/main/java/org/acra/collector/CustomDataCollector.java#L70), presumably for a good reason somewhere else in the code. However, when I send a report via email, the custom data contains the escaped newlines (`\n`) in the custom data instead of real newlines. Is there just a step missing in [EmailIntentSender](https://github.com/ACRA/acra/blob/master/src/main/java/org/acra/sender/EmailIntentSender.java)?

This is the code I'm using to update the custom data. I'm keeping a log by appending messages to a single custom data key.

```
            String log = errorReporter.getCustomData(LOG_KEY);
            if (log == null) {
                log = fullMessage;
            } else {
                log = String.format("%s%n%s", log, fullMessage);
            }

            errorReporter.putCustomData(LOG_KEY, log);
```

I'm using version 4.9.1, but have also tested with the development version and the problem still exists.