### PR TITLE
Add res folder and R.txt to AAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 			<plugin>
 				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
-				<version>4.4.2</version>
+				<version>4.4.3</version>
 				<extensions>true</extensions>
 				<configuration>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is just here to force android-maven-plugin:4.4.3 to include a /res folder in the AAR
+which is now a requirement https://developer.android.com/studio/projects/android-library.html#aar-contents
+-->
+<resources>
+    <string name="not_used">Only here to ensure that android-maven-plugin:4.4.3 creates an R.txt</string>
+</resources>


### PR DESCRIPTION
Added bogus resource entry to force android-maven-plugin to create res folder and R.txt in AAR to conform to AAR file structure. Fix for #538