### PR TITLE
update to Android Studio 3.0.1

### DIFF
--- a/acra/build.gradle
+++ b/acra/build.gradle
@@ -6,14 +6,14 @@ apply plugin: 'com.jfrog.artifactory'
 
 android {
     compileSdkVersion Integer.parseInt(androidVersion)
-    buildToolsVersion '25.0.2'
+    buildToolsVersion '26.0.2'
 
     lintOptions {
         abortOnError false
     }
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 14
         targetSdkVersion androidVersion
         versionName version
         consumerProguardFile proguardFile

--- a/acra/gradle.properties
+++ b/acra/gradle.properties
@@ -1,8 +1,8 @@
 version=4.10.1-SNAPSHOT
 group=com.faendir
 archivesBaseName=acra
-androidVersion=24
-supportVersion=24.1.1
+androidVersion=26
+supportVersion=27.0.2
 proguardFile=src/main/proguard/proguard.cfg
 release.useAutomaticVersion=true
 ossrhUser=

--- a/annotationprocessor/build.gradle
+++ b/annotationprocessor/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'java'
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.google.auto.service:auto-service:1.0-rc2'
-    compile 'com.squareup:javapoet:1.7.0'
+    compile 'com.squareup:javapoet:1.9.0'
     compile project(':annotations')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.0"
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.9.0"
         classpath 'net.researchgate:gradle-release:2.5.0'
@@ -21,6 +22,7 @@ apply plugin: 'io.codearte.nexus-staging'
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Feb 17 03:38:03 CET 2017
+#Fri Dec 01 22:42:15 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
I see in my project 
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/3314607/33504914-a6ef289c-d6e9-11e7-9f82-ee45f3176428.png">
and I want to get rid of it, so I made a PR to update to most recent stable Android Studio.

The downsize is a minSdk 14 instead if archeological 8. If someone says, oh we still on Android 2.3, then he can still stay on acra 4.9.2
