### PR TITLE
Warn from getErrorReporter instead of throwing exception

### DIFF
--- a/acra-core/src/main/java/org/acra/ErrorReporter.java
+++ b/acra-core/src/main/java/org/acra/ErrorReporter.java
@@ -1,99 +1,20 @@
-/*
- *  Copyright 2010 Emmanuel Astier &amp; Kevin Gaudin
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
 package org.acra;
 
-import android.app.Application;
-import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import org.acra.builder.LastActivityManager;
-import org.acra.builder.ReportBuilder;
-import org.acra.builder.ReportExecutor;
-import org.acra.data.CrashReportDataFactory;
-import org.acra.config.CoreConfiguration;
-import org.acra.util.InstanceCreator;
-import org.acra.util.ProcessFinisher;
-
-import java.lang.Thread.UncaughtExceptionHandler;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.acra.ACRA.LOG_TAG;
-
 /**
- * <p>
- * The ErrorReporter is a Singleton object in charge of collecting crash context
- * data and sending crash reports. It registers itself as the Application's
- * Thread default {@link UncaughtExceptionHandler}.
- * </p>
- * <p>
- * When a crash occurs, it collects data of the crash context (device, system,
- * stack trace...) and writes a report file in the application private
- * directory, which may then be sent.
- * </p>
+ * This interface contains methods used to interact with ACRA after it has been initialized
+ *
+ * @author F43nd1r
+ * @since 29.12.2017
  */
-@SuppressWarnings({"WeakerAccess", "unused", "SameParameterValue"})
-public class ErrorReporter implements Thread.UncaughtExceptionHandler, SharedPreferences.OnSharedPreferenceChangeListener {
 
-    private final boolean supportedAndroidVersion;
-
-    private final Application context;
-
-    @NonNull
-    private final ReportExecutor reportExecutor;
-
-    private final Map<String, String> customData = new HashMap<>();
-
-
+public interface ErrorReporter {
     /**
-     * Can only be constructed from within this class.
-     *  @param context                     Context for the application in which ACRA is running.
-     * @param config                      AcraConfig to use when reporting and sending errors.
-     * @param enabled                     Whether this ErrorReporter should capture Exceptions and forward their reports.
-     */
-    ErrorReporter(@NonNull Application context, @NonNull CoreConfiguration config,
-                  boolean enabled, boolean supportedAndroidVersion) {
-
-        this.context = context;
-        this.supportedAndroidVersion = supportedAndroidVersion;
-
-        final CrashReportDataFactory crashReportDataFactory = new CrashReportDataFactory(context, config);
-        crashReportDataFactory.collectStartUp();
-
-        final Thread.UncaughtExceptionHandler defaultExceptionHandler;
-        defaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
-        Thread.setDefaultUncaughtExceptionHandler(this);
-
-        final LastActivityManager lastActivityManager = new LastActivityManager(this.context);
-        final InstanceCreator instanceCreator = new InstanceCreator();
-        final ProcessFinisher processFinisher = new ProcessFinisher(context, config, lastActivityManager);
-
-        reportExecutor = new ReportExecutor(context, config, crashReportDataFactory, defaultExceptionHandler, processFinisher);
-        reportExecutor.setEnabled(enabled);
-    }
-
-    /**
-     * <p>
-     * Use this method to provide the ErrorReporter with data of your running
-     * application. You should call this at several key places in your code the
-     * same way as you would output important debug data in a log file. Only the
-     * latest value is kept for each key (no history of the values is sent in
-     * the report).
-     * </p>
+     * Use this method to provide the ErrorReporter with data of your running application.
+     * You should call this at several key places in your code the same way as you would output important debug data in a log file.
+     * Only the latest value is kept for each key (no history of the values is sent in the report).
      *
      * @param key   A key for your custom data.
      * @param value The value associated to your key.
@@ -101,9 +22,7 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler, SharedPre
      * @see #removeCustomData(String)
      * @see #getCustomData(String)
      */
-    public String putCustomData(@NonNull String key, String value) {
-        return customData.put(key, value);
-    }
+    String putCustomData(@NonNull String key, String value);
 
     /**
      * Removes a key/value pair from your reports custom data field.
@@ -113,16 +32,12 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler, SharedPre
      * @see #putCustomData(String, String)
      * @see #getCustomData(String)
      */
-    public String removeCustomData(@NonNull String key) {
-        return customData.remove(key);
-    }
+    String removeCustomData(@NonNull String key);
 
     /**
      * Removes all key/value pairs from your reports custom data field.
      */
-    public void clearCustomData() {
-        customData.clear();
-    }
+    void clearCustomData();
 
     /**
      * Gets the current value for a key in your reports custom data field.
@@ -132,109 +47,41 @@ public class ErrorReporter implements Thread.UncaughtExceptionHandler, SharedPre
      * @see #putCustomData(String, String)
      * @see #removeCustomData(String)
      */
-    public String getCustomData(@NonNull String key) {
-        return customData.get(key);
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * java.lang.Thread.UncaughtExceptionHandler#uncaughtException(java.lang
-     * .Thread, java.lang.Throwable)
-     */
-    @Override
-    public void uncaughtException(@Nullable Thread t, @NonNull Throwable e) {
-
-        // If we're not enabled then just pass the Exception on to the defaultExceptionHandler.
-        if (!reportExecutor.isEnabled()) {
-            reportExecutor.handReportToDefaultExceptionHandler(t, e);
-            return;
-        }
-
-        try {
-            ACRA.log.e(LOG_TAG, "ACRA caught a " + e.getClass().getSimpleName() + " for " + context.getPackageName(), e);
-            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Building report");
-
-            // Generate and send crash report
-            new ReportBuilder()
-                    .uncaughtExceptionThread(t)
-                    .exception(e)
-                    .customData(customData)
-                    .endApplication()
-                    .build(reportExecutor);
-
-        } catch (Throwable fatality) {
-            // ACRA failed. Prevent any recursive call to ACRA.uncaughtException(), let the native reporter do its job.
-            ACRA.log.e(LOG_TAG, "ACRA failed to capture the error - handing off to native error reporter", fatality);
-            reportExecutor.handReportToDefaultExceptionHandler(t, e);
-        }
-    }
+    String getCustomData(@NonNull String key);
 
     /**
-     * Mark this report as silent as send it.
+     * Send a silent report for the given exception
      *
-     * @param e The {@link Throwable} to be reported. If null the report will
-     *          contain a new Exception("Report requested by developer").
+     * @param e The {@link Throwable} to be reported. If null the report will contain a new Exception("Report requested by developer").
      */
-    public void handleSilentException(@Nullable Throwable e) {
-        new ReportBuilder()
-                .exception(e)
-                .customData(customData)
-                .sendSilently()
-                .build(reportExecutor);
-    }
+    void handleSilentException(@Nullable Throwable e);
+
 
     /**
      * Enable or disable this ErrorReporter. By default it is enabled.
      *
-     * @param enabled Whether this ErrorReporter should capture Exceptions and
-     *                forward them as crash reports.
+     * @param enabled Whether this ErrorReporter should capture Exceptions and forward them as crash reports.
      */
-    public void setEnabled(boolean enabled) {
-        if (supportedAndroidVersion) {
-            ACRA.log.i(LOG_TAG, "ACRA is " + (enabled ? "enabled" : "disabled") + " for " + context.getPackageName());
-            reportExecutor.setEnabled(enabled);
-        } else {
-            ACRA.log.w(LOG_TAG, "ACRA 4.7.0+ requires Froyo or greater. ACRA is disabled and will NOT catch crashes or send messages.");
-        }
-    }
+    void setEnabled(boolean enabled);
 
     /**
-     * Send a report for a {@link Throwable} with the reporting interaction mode
-     * configured by the developer.
-     *
-     * @param e              The {@link Throwable} to be reported. If null the report will
-     *                       contain a new Exception("Report requested by developer").
-     * @param endApplication Set this to true if you want the application to be ended after
-     *                       sending the report.
+     * @return if this instance is the current DefaultUncaughtExceptionHandler
      */
-    public void handleException(@Nullable Throwable e, boolean endApplication) {
-        final ReportBuilder builder = new ReportBuilder();
-        builder.exception(e)
-                .customData(customData);
-        if (endApplication) {
-            builder.endApplication();
-        }
-        builder.build(reportExecutor);
-    }
+    boolean isRegistered();
 
     /**
-     * Send a report for a {@link Throwable} with the reporting interaction mode
-     * configured by the developer, the application is then killed and restarted
-     * by the system.
+     * Send a normal report for the given exception
      *
-     * @param e The {@link Throwable} to be reported. If null the report will
-     *          contain a new Exception("Report requested by developer").
+     * @param e              The {@link Throwable} to be reported. If null the report will contain a new Exception("Report requested by developer").
+     * @param endApplication if you want the application to be ended after sending the report.
      */
-    public void handleException(@Nullable Throwable e) {
-        handleException(e, false);
-    }
+    void handleException(@Nullable Throwable e, boolean endApplication);
 
-    @Override
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (ACRA.PREF_DISABLE_ACRA.equals(key) || ACRA.PREF_ENABLE_ACRA.equals(key)) {
-            setEnabled(!ACRA.shouldDisableACRA(sharedPreferences));
-        }
-    }
+    /**
+     * Send a normal report for the given exception.
+     * The application is then killed and restarted by the system.
+     *
+     * @param e The {@link Throwable} to be reported. If null the report will contain a new Exception("Report requested by developer").
+     */
+    void handleException(@Nullable Throwable e);
 }

--- a/acra-core/src/main/java/org/acra/prefs/SharedPreferencesFactory.java
+++ b/acra-core/src/main/java/org/acra/prefs/SharedPreferencesFactory.java
@@ -21,6 +21,7 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 
+import org.acra.ACRA;
 import org.acra.ACRAConstants;
 import org.acra.config.CoreConfiguration;
 
@@ -39,6 +40,26 @@ public class SharedPreferencesFactory {
     public SharedPreferencesFactory(@NonNull Context context, @NonNull CoreConfiguration config) {
         this.context = context;
         this.config = config;
+    }
+
+    /**
+     * Check if the application default shared preferences contains true for the
+     * key "acra.disable", do not activate ACRA. Also checks the alternative
+     * opposite setting "acra.enable" if "acra.disable" is not found.
+     *
+     * @param prefs SharedPreferences to check to see whether ACRA should be
+     *              disabled.
+     * @return true if prefs indicate that ACRA should be disabled.
+     */
+    public static boolean shouldDisableACRA(@NonNull SharedPreferences prefs) {
+        boolean disableAcra = false;
+        try {
+            final boolean enableAcra = prefs.getBoolean(ACRA.PREF_ENABLE_ACRA, true);
+            disableAcra = prefs.getBoolean(ACRA.PREF_DISABLE_ACRA, !enableAcra);
+        } catch (Exception e) {
+            // In case of a ClassCastException
+        }
+        return disableAcra;
     }
 
     /**

--- a/acra-core/src/main/java/org/acra/reporter/ErrorReporterImpl.java
+++ b/acra-core/src/main/java/org/acra/reporter/ErrorReporterImpl.java
@@ -63,10 +63,10 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
 
 
     /**
-     * Can only be constructed from within this class.
-     *  @param context                     Context for the application in which ACRA is running.
-     * @param config                      AcraConfig to use when reporting and sending errors.
-     * @param enabled                     Whether this ErrorReporter should capture Exceptions and forward their reports.
+     * @param context                 Context for the application in which ACRA is running.
+     * @param config                  AcraConfig to use when reporting and sending errors.
+     * @param enabled                 Whether this ErrorReporter should capture Exceptions and forward their reports.
+     * @param supportedAndroidVersion the minimal supported version
      */
     public ErrorReporterImpl(@NonNull Application context, @NonNull CoreConfiguration config,
                              boolean enabled, boolean supportedAndroidVersion) {
@@ -90,19 +90,7 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
     }
 
     /**
-     * <p>
-     * Use this method to provide the ErrorReporter with data of your running
-     * application. You should call this at several key places in your code the
-     * same way as you would output important debug data in a log file. Only the
-     * latest value is kept for each key (no history of the values is sent in
-     * the report).
-     * </p>
-     *
-     * @param key   A key for your custom data.
-     * @param value The value associated to your key.
-     * @return The previous value for this key if there was one, or null.
-     * @see #removeCustomData(String)
-     * @see #getCustomData(String)
+     * {@inheritDoc}
      */
     @Override
     public String putCustomData(@NonNull String key, String value) {
@@ -110,12 +98,7 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
     }
 
     /**
-     * Removes a key/value pair from your reports custom data field.
-     *
-     * @param key The key of the data to be removed.
-     * @return The value for this key before removal.
-     * @see #putCustomData(String, String)
-     * @see #getCustomData(String)
+     * {@inheritDoc}
      */
     @Override
     public String removeCustomData(@NonNull String key) {
@@ -123,7 +106,7 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
     }
 
     /**
-     * Removes all key/value pairs from your reports custom data field.
+     * {@inheritDoc}
      */
     @Override
     public void clearCustomData() {
@@ -131,12 +114,7 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
     }
 
     /**
-     * Gets the current value for a key in your reports custom data field.
-     *
-     * @param key The key of the data to be retrieved.
-     * @return The value for this key.
-     * @see #putCustomData(String, String)
-     * @see #removeCustomData(String)
+     * {@inheritDoc}
      */
     @Override
     public String getCustomData(@NonNull String key) {
@@ -179,10 +157,7 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
     }
 
     /**
-     * Mark this report as silent as send it.
-     *
-     * @param e The {@link Throwable} to be reported. If null the report will
-     *          contain a new Exception("Report requested by developer").
+     * {@inheritDoc}
      */
     @Override
     public void handleSilentException(@Nullable Throwable e) {
@@ -194,10 +169,7 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
     }
 
     /**
-     * Enable or disable this ErrorReporter. By default it is enabled.
-     *
-     * @param enabled Whether this ErrorReporter should capture Exceptions and
-     *                forward them as crash reports.
+     * {@inheritDoc}
      */
     @Override
     public void setEnabled(boolean enabled) {
@@ -209,19 +181,16 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isRegistered() {
         return Thread.getDefaultUncaughtExceptionHandler() == this;
     }
 
     /**
-     * Send a report for a {@link Throwable} with the reporting interaction mode
-     * configured by the developer.
-     *
-     * @param e              The {@link Throwable} to be reported. If null the report will
-     *                       contain a new Exception("Report requested by developer").
-     * @param endApplication Set this to true if you want the application to be ended after
-     *                       sending the report.
+     * {@inheritDoc}
      */
     @Override
     public void handleException(@Nullable Throwable e, boolean endApplication) {
@@ -235,12 +204,7 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
     }
 
     /**
-     * Send a report for a {@link Throwable} with the reporting interaction mode
-     * configured by the developer, the application is then killed and restarted
-     * by the system.
-     *
-     * @param e The {@link Throwable} to be reported. If null the report will
-     *          contain a new Exception("Report requested by developer").
+     * {@inheritDoc}
      */
     @Override
     public void handleException(@Nullable Throwable e) {

--- a/acra-core/src/main/java/org/acra/reporter/ErrorReporterImpl.java
+++ b/acra-core/src/main/java/org/acra/reporter/ErrorReporterImpl.java
@@ -1,0 +1,256 @@
+/*
+ *  Copyright 2010 Emmanuel Astier &amp; Kevin Gaudin
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.acra.reporter;
+
+import android.app.Application;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.acra.ACRA;
+import org.acra.ErrorReporter;
+import org.acra.builder.LastActivityManager;
+import org.acra.builder.ReportBuilder;
+import org.acra.builder.ReportExecutor;
+import org.acra.data.CrashReportDataFactory;
+import org.acra.config.CoreConfiguration;
+import org.acra.prefs.SharedPreferencesFactory;
+import org.acra.util.InstanceCreator;
+import org.acra.util.ProcessFinisher;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.acra.ACRA.LOG_TAG;
+
+/**
+ * <p>
+ * The ErrorReporter is a Singleton object in charge of collecting crash context
+ * data and sending crash reports. It registers itself as the Application's
+ * Thread default {@link UncaughtExceptionHandler}.
+ * </p>
+ * <p>
+ * When a crash occurs, it collects data of the crash context (device, system,
+ * stack trace...) and writes a report file in the application private
+ * directory, which may then be sent.
+ * </p>
+ */
+@SuppressWarnings({"WeakerAccess", "unused", "SameParameterValue"})
+public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, SharedPreferences.OnSharedPreferenceChangeListener, ErrorReporter {
+
+    private final boolean supportedAndroidVersion;
+
+    private final Application context;
+
+    @NonNull
+    private final ReportExecutor reportExecutor;
+
+    private final Map<String, String> customData = new HashMap<>();
+
+
+    /**
+     * Can only be constructed from within this class.
+     *  @param context                     Context for the application in which ACRA is running.
+     * @param config                      AcraConfig to use when reporting and sending errors.
+     * @param enabled                     Whether this ErrorReporter should capture Exceptions and forward their reports.
+     */
+    public ErrorReporterImpl(@NonNull Application context, @NonNull CoreConfiguration config,
+                             boolean enabled, boolean supportedAndroidVersion) {
+
+        this.context = context;
+        this.supportedAndroidVersion = supportedAndroidVersion;
+
+        final CrashReportDataFactory crashReportDataFactory = new CrashReportDataFactory(context, config);
+        crashReportDataFactory.collectStartUp();
+
+        final Thread.UncaughtExceptionHandler defaultExceptionHandler;
+        defaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler(this);
+
+        final LastActivityManager lastActivityManager = new LastActivityManager(this.context);
+        final InstanceCreator instanceCreator = new InstanceCreator();
+        final ProcessFinisher processFinisher = new ProcessFinisher(context, config, lastActivityManager);
+
+        reportExecutor = new ReportExecutor(context, config, crashReportDataFactory, defaultExceptionHandler, processFinisher);
+        reportExecutor.setEnabled(enabled);
+    }
+
+    /**
+     * <p>
+     * Use this method to provide the ErrorReporter with data of your running
+     * application. You should call this at several key places in your code the
+     * same way as you would output important debug data in a log file. Only the
+     * latest value is kept for each key (no history of the values is sent in
+     * the report).
+     * </p>
+     *
+     * @param key   A key for your custom data.
+     * @param value The value associated to your key.
+     * @return The previous value for this key if there was one, or null.
+     * @see #removeCustomData(String)
+     * @see #getCustomData(String)
+     */
+    @Override
+    public String putCustomData(@NonNull String key, String value) {
+        return customData.put(key, value);
+    }
+
+    /**
+     * Removes a key/value pair from your reports custom data field.
+     *
+     * @param key The key of the data to be removed.
+     * @return The value for this key before removal.
+     * @see #putCustomData(String, String)
+     * @see #getCustomData(String)
+     */
+    @Override
+    public String removeCustomData(@NonNull String key) {
+        return customData.remove(key);
+    }
+
+    /**
+     * Removes all key/value pairs from your reports custom data field.
+     */
+    @Override
+    public void clearCustomData() {
+        customData.clear();
+    }
+
+    /**
+     * Gets the current value for a key in your reports custom data field.
+     *
+     * @param key The key of the data to be retrieved.
+     * @return The value for this key.
+     * @see #putCustomData(String, String)
+     * @see #removeCustomData(String)
+     */
+    @Override
+    public String getCustomData(@NonNull String key) {
+        return customData.get(key);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * java.lang.Thread.UncaughtExceptionHandler#uncaughtException(java.lang
+     * .Thread, java.lang.Throwable)
+     */
+    @Override
+    public void uncaughtException(@Nullable Thread t, @NonNull Throwable e) {
+
+        // If we're not enabled then just pass the Exception on to the defaultExceptionHandler.
+        if (!reportExecutor.isEnabled()) {
+            reportExecutor.handReportToDefaultExceptionHandler(t, e);
+            return;
+        }
+
+        try {
+            ACRA.log.e(LOG_TAG, "ACRA caught a " + e.getClass().getSimpleName() + " for " + context.getPackageName(), e);
+            if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Building report");
+
+            // Generate and send crash report
+            new ReportBuilder()
+                    .uncaughtExceptionThread(t)
+                    .exception(e)
+                    .customData(customData)
+                    .endApplication()
+                    .build(reportExecutor);
+
+        } catch (Throwable fatality) {
+            // ACRA failed. Prevent any recursive call to ACRA.uncaughtException(), let the native reporter do its job.
+            ACRA.log.e(LOG_TAG, "ACRA failed to capture the error - handing off to native error reporter", fatality);
+            reportExecutor.handReportToDefaultExceptionHandler(t, e);
+        }
+    }
+
+    /**
+     * Mark this report as silent as send it.
+     *
+     * @param e The {@link Throwable} to be reported. If null the report will
+     *          contain a new Exception("Report requested by developer").
+     */
+    @Override
+    public void handleSilentException(@Nullable Throwable e) {
+        new ReportBuilder()
+                .exception(e)
+                .customData(customData)
+                .sendSilently()
+                .build(reportExecutor);
+    }
+
+    /**
+     * Enable or disable this ErrorReporter. By default it is enabled.
+     *
+     * @param enabled Whether this ErrorReporter should capture Exceptions and
+     *                forward them as crash reports.
+     */
+    @Override
+    public void setEnabled(boolean enabled) {
+        if (supportedAndroidVersion) {
+            ACRA.log.i(LOG_TAG, "ACRA is " + (enabled ? "enabled" : "disabled") + " for " + context.getPackageName());
+            reportExecutor.setEnabled(enabled);
+        } else {
+            ACRA.log.w(LOG_TAG, "ACRA 4.7.0+ requires Froyo or greater. ACRA is disabled and will NOT catch crashes or send messages.");
+        }
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return Thread.getDefaultUncaughtExceptionHandler() == this;
+    }
+
+    /**
+     * Send a report for a {@link Throwable} with the reporting interaction mode
+     * configured by the developer.
+     *
+     * @param e              The {@link Throwable} to be reported. If null the report will
+     *                       contain a new Exception("Report requested by developer").
+     * @param endApplication Set this to true if you want the application to be ended after
+     *                       sending the report.
+     */
+    @Override
+    public void handleException(@Nullable Throwable e, boolean endApplication) {
+        final ReportBuilder builder = new ReportBuilder();
+        builder.exception(e)
+                .customData(customData);
+        if (endApplication) {
+            builder.endApplication();
+        }
+        builder.build(reportExecutor);
+    }
+
+    /**
+     * Send a report for a {@link Throwable} with the reporting interaction mode
+     * configured by the developer, the application is then killed and restarted
+     * by the system.
+     *
+     * @param e The {@link Throwable} to be reported. If null the report will
+     *          contain a new Exception("Report requested by developer").
+     */
+    @Override
+    public void handleException(@Nullable Throwable e) {
+        handleException(e, false);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (ACRA.PREF_DISABLE_ACRA.equals(key) || ACRA.PREF_ENABLE_ACRA.equals(key)) {
+            setEnabled(!SharedPreferencesFactory.shouldDisableACRA(sharedPreferences));
+        }
+    }
+}

--- a/acra-core/src/main/java/org/acra/reporter/ErrorReporterStub.java
+++ b/acra-core/src/main/java/org/acra/reporter/ErrorReporterStub.java
@@ -1,0 +1,70 @@
+package org.acra.reporter;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.acra.ACRA;
+import org.acra.ErrorReporter;
+
+/**
+ * @author F43nd1r
+ * @since 29.12.2017
+ */
+
+public class ErrorReporterStub implements ErrorReporter {
+    @Override
+    public String putCustomData(@NonNull String key, String value) {
+        warnStubCalled();
+        return null;
+    }
+
+    @Override
+    public String removeCustomData(@NonNull String key) {
+        warnStubCalled();
+        return null;
+    }
+
+    @Override
+    public void clearCustomData() {
+        warnStubCalled();
+
+    }
+
+    @Override
+    public String getCustomData(@NonNull String key) {
+        warnStubCalled();
+        return null;
+    }
+
+    @Override
+    public void handleSilentException(@Nullable Throwable e) {
+        warnStubCalled();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        warnStubCalled();
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return false;
+    }
+
+    @Override
+    public void handleException(@Nullable Throwable e, boolean endApplication) {
+        warnStubCalled();
+    }
+
+    @Override
+    public void handleException(@Nullable Throwable e) {
+        warnStubCalled();
+    }
+
+    private void warnStubCalled() {
+        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+        String methodName = stackTraceElements.length > 3 ? stackTraceElements[3].getMethodName() : null;
+        String message = ACRA.isACRASenderServiceProcess() ? "in SenderService process" : "before ACRA#init (if you did call #init, check if your configuration is valid)";
+        ACRA.log.w(ACRA.LOG_TAG, String.format("ErrorReporter#%s called %s. THIS CALL WILL BE IGNORED!", methodName, message));
+    }
+}


### PR DESCRIPTION
Alternative to #614 
We probably shouldn't throw exceptions as a crash reporting library.