### PR TITLE
Http attachment improvements

### DIFF
--- a/acra-core/src/main/java/org/acra/annotation/AcraCore.java
+++ b/acra-core/src/main/java/org/acra/annotation/AcraCore.java
@@ -268,7 +268,7 @@ public @interface AcraCore {
      * </p>
      * Side effects:
      * <ul>
-     * <li>POST mode: requests will be sent with content-type multipart/mixed</li>
+     * <li>POST mode: requests will be sent with content-type multipart/form-data</li>
      * <li>PUT mode: There will be additional requests with the attachments. Naming scheme: [report-id]-[filename]</li>
      * <li>EMAIL mode: Some email clients do not support attachments, so some email may lack these attachments. Note that attachments might be readable to email clients when they are sent.</li>
      * </ul>

--- a/acra-http/src/main/java/org/acra/http/BaseHttpRequest.java
+++ b/acra-http/src/main/java/org/acra/http/BaseHttpRequest.java
@@ -174,7 +174,6 @@ public abstract class BaseHttpRequest<T> implements HttpRequest<T> {
 
     @SuppressWarnings("WeakerAccess")
     protected void writeContent(@NonNull HttpURLConnection connection, @NonNull Method method, @NonNull T content) throws IOException {
-        final byte[] contentAsBytes = asBytes(content);
         // write output - see http://developer.android.com/reference/java/net/HttpURLConnection.html
         connection.setRequestMethod(method.name());
         connection.setDoOutput(true);
@@ -187,15 +186,14 @@ public abstract class BaseHttpRequest<T> implements HttpRequest<T> {
         final OutputStream outputStream = senderConfiguration.compress() ? new GZIPOutputStream(connection.getOutputStream(), ACRAConstants.DEFAULT_BUFFER_SIZE_IN_BYTES)
                 : new BufferedOutputStream(connection.getOutputStream());
         try {
-            outputStream.write(contentAsBytes);
+            write(outputStream, content);
             outputStream.flush();
         } finally {
             IOUtils.safeClose(outputStream);
         }
     }
 
-    @NonNull
-    protected abstract byte[] asBytes(@NonNull T content) throws IOException;
+    protected abstract void write(OutputStream outputStream, @NonNull T content) throws IOException;
 
     @SuppressWarnings("WeakerAccess")
     protected void handleResponse(int responseCode, String responseMessage) throws IOException {

--- a/acra-http/src/main/java/org/acra/http/BinaryHttpRequest.java
+++ b/acra-http/src/main/java/org/acra/http/BinaryHttpRequest.java
@@ -26,6 +26,7 @@ import org.acra.sender.HttpSender;
 import org.acra.util.UriUtils;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Map;
 
 /**
@@ -48,9 +49,8 @@ public class BinaryHttpRequest extends BaseHttpRequest<Uri> {
         return UriUtils.getMimeType(context, uri);
     }
 
-    @NonNull
     @Override
-    protected byte[] asBytes(@NonNull Uri content) throws IOException {
-        return UriUtils.uriToByteArray(context, content);
+    protected void write(OutputStream outputStream, @NonNull Uri content) throws IOException {
+        UriUtils.copyFromUri(context, outputStream, content);
     }
 }

--- a/acra-http/src/main/java/org/acra/http/DefaultHttpRequest.java
+++ b/acra-http/src/main/java/org/acra/http/DefaultHttpRequest.java
@@ -24,6 +24,7 @@ import org.acra.config.CoreConfiguration;
 import org.acra.sender.HttpSender;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Map;
 
 /**
@@ -46,9 +47,8 @@ public class DefaultHttpRequest extends BaseHttpRequest<String> {
         return contentType;
     }
 
-    @NonNull
     @Override
-    protected byte[] asBytes(@NonNull String content) throws IOException {
-        return content.getBytes(ACRAConstants.UTF8);
+    protected void write(OutputStream outputStream, @NonNull String content) throws IOException {
+        outputStream.write(content.getBytes(ACRAConstants.UTF8));
     }
 }

--- a/acra-http/src/main/java/org/acra/http/MultipartHttpRequest.java
+++ b/acra-http/src/main/java/org/acra/http/MultipartHttpRequest.java
@@ -21,15 +21,13 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Pair;
+import org.acra.ACRA;
 import org.acra.ACRAConstants;
 import org.acra.config.CoreConfiguration;
 import org.acra.sender.HttpSender;
 import org.acra.util.UriUtils;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
+import java.io.*;
 import java.util.List;
 import java.util.Map;
 
@@ -74,12 +72,17 @@ public class MultipartHttpRequest extends BaseHttpRequest<Pair<String, List<Uri>
                 .append(NEW_LINE)
                 .append(content.first);
         for (Uri uri : content.second) {
-            writer.append(SECTION_START)
-                    .format(CONTENT_DISPOSITION, "ACRA_ATTACHMENT", UriUtils.getFileNameFromUri(context, uri))
-                    .format(CONTENT_TYPE, UriUtils.getMimeType(context, uri))
-                    .append(NEW_LINE)
-                    .flush();
-            UriUtils.copyFromUri(context, outputStream, uri);
+            try {
+                String name = UriUtils.getFileNameFromUri(context, uri);
+                writer.append(SECTION_START)
+                        .format(CONTENT_DISPOSITION, "ACRA_ATTACHMENT", name)
+                        .format(CONTENT_TYPE, UriUtils.getMimeType(context, uri))
+                        .append(NEW_LINE)
+                        .flush();
+                UriUtils.copyFromUri(context, outputStream, uri);
+            } catch (FileNotFoundException e) {
+                ACRA.log.w("Not sending attachment", e);
+            }
         }
         writer.append(MESSAGE_END).flush();
     }

--- a/acra-http/src/main/java/org/acra/http/MultipartHttpRequest.java
+++ b/acra-http/src/main/java/org/acra/http/MultipartHttpRequest.java
@@ -26,12 +26,15 @@ import org.acra.config.CoreConfiguration;
 import org.acra.sender.HttpSender;
 import org.acra.util.UriUtils;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Produces <a href="https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html">RFC 1341</a> compliant requests
+ * Produces <a href="https://tools.ietf.org/html/rfc7578">RFC 7578</a> compliant requests
  *
  * @author F43nd1r
  * @since 11.03.2017
@@ -42,7 +45,10 @@ public class MultipartHttpRequest extends BaseHttpRequest<Pair<String, List<Uri>
     private static final String BOUNDARY = "%&ACRA_REPORT_DIVIDER&%";
     private static final String BOUNDARY_FIX = "--";
     private static final String NEW_LINE = "\r\n";
-    private static final String CONTENT_TYPE = "Content-Type: ";
+    private static final String SECTION_START = NEW_LINE + BOUNDARY_FIX + BOUNDARY + NEW_LINE;
+    private static final String MESSAGE_END = NEW_LINE + BOUNDARY_FIX + BOUNDARY + BOUNDARY_FIX + NEW_LINE;
+    private static final String CONTENT_DISPOSITION = "Content-Disposition: form-data; name=\"%s\"; filename=\"%s\"" + NEW_LINE;
+    private static final String CONTENT_TYPE = "Content-Type: %s" + NEW_LINE;
     private final Context context;
     private final String contentType;
 
@@ -56,23 +62,25 @@ public class MultipartHttpRequest extends BaseHttpRequest<Pair<String, List<Uri>
     @NonNull
     @Override
     protected String getContentType(@NonNull Context context, @NonNull Pair<String, List<Uri>> stringListPair) {
-        return "multipart/mixed; boundary=" + BOUNDARY;
+        return "multipart/form-data; boundary=" + BOUNDARY;
     }
 
     @Override
     protected void write(OutputStream outputStream, @NonNull Pair<String, List<Uri>> content) throws IOException {
-        final Writer writer = new OutputStreamWriter(outputStream, ACRAConstants.UTF8);
-        writer.append(NEW_LINE).append(BOUNDARY_FIX).append(BOUNDARY).append(NEW_LINE);
-        writer.append(CONTENT_TYPE).append(contentType).append(NEW_LINE).append(NEW_LINE);
-        writer.append(content.first);
+        final PrintWriter writer = new PrintWriter(new OutputStreamWriter(outputStream, ACRAConstants.UTF8));
+        writer.append(SECTION_START)
+                .format(CONTENT_DISPOSITION, "ACRA_REPORT", "")
+                .format(CONTENT_TYPE, contentType)
+                .append(NEW_LINE)
+                .append(content.first);
         for (Uri uri : content.second) {
-            writer.append(NEW_LINE).append(BOUNDARY_FIX).append(BOUNDARY).append(NEW_LINE);
-            writer.append("Content-Disposition: attachment; filename=\"").append(UriUtils.getFileNameFromUri(context, uri)).append('"').append(NEW_LINE);
-            writer.append(CONTENT_TYPE).append(UriUtils.getMimeType(context, uri)).append(NEW_LINE).append(NEW_LINE);
-            writer.flush();
+            writer.append(SECTION_START)
+                    .format(CONTENT_DISPOSITION, "ACRA_ATTACHMENT", UriUtils.getFileNameFromUri(context, uri))
+                    .format(CONTENT_TYPE, UriUtils.getMimeType(context, uri))
+                    .append(NEW_LINE)
+                    .flush();
             UriUtils.copyFromUri(context, outputStream, uri);
         }
-        writer.append(NEW_LINE).append(BOUNDARY_FIX).append(BOUNDARY).append(BOUNDARY_FIX).append(NEW_LINE);
-        writer.flush();
+        writer.append(MESSAGE_END).flush();
     }
 }

--- a/acra-http/src/main/java/org/acra/util/UriUtils.java
+++ b/acra-http/src/main/java/org/acra/util/UriUtils.java
@@ -26,10 +26,7 @@ import android.support.annotation.NonNull;
 import org.acra.ACRAConstants;
 import org.acra.attachment.AcraContentProvider;
 
-import java.io.ByteArrayOutputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 
 /**
  * @author F43nd1r
@@ -40,19 +37,17 @@ public final class UriUtils {
     private UriUtils() {
     }
 
-    @NonNull
-    public static byte[] uriToByteArray(@NonNull Context context, @NonNull Uri uri) throws IOException {
-        final InputStream inputStream = context.getContentResolver().openInputStream(uri);
-        if (inputStream == null) {
-            throw new FileNotFoundException("Could not open " + uri.toString());
+    public static void copyFromUri(@NonNull Context context, @NonNull OutputStream outputStream, @NonNull Uri uri) throws IOException {
+        try(final InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
+            if (inputStream == null) {
+                throw new FileNotFoundException("Could not open " + uri.toString());
+            }
+            final byte[] buffer = new byte[ACRAConstants.DEFAULT_BUFFER_SIZE_IN_BYTES];
+            int length;
+            while ((length = inputStream.read(buffer)) > 0) {
+                outputStream.write(buffer, 0, length);
+            }
         }
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        final byte[] buffer = new byte[ACRAConstants.DEFAULT_BUFFER_SIZE_IN_BYTES];
-        int length;
-        while ((length = inputStream.read(buffer)) > 0) {
-            outputStream.write(buffer, 0, length);
-        }
-        return outputStream.toByteArray();
     }
 
     @NonNull


### PR DESCRIPTION
- dont load full message in byte array
- Send multipart-formdata instead of multipart-mixed, because it is better supported
- allow missing attachments