### PR TITLE
Allow easier testing

### DIFF
--- a/acra-core/src/main/java/org/acra/ACRA.java
+++ b/acra-core/src/main/java/org/acra/ACRA.java
@@ -205,8 +205,10 @@ public final class ACRA {
         }
 
         if (isInitialised()) {
-            log.w(LOG_TAG, "ACRA#init called more than once. Won't do anything more.");
-            return;
+            log.w(LOG_TAG, "ACRA#init called more than once. This might have unexpected side effects. Doing this outside of tests is discouraged.");
+            if(DEV_LOGGING) log.d(LOG_TAG, "Removing old ACRA config...");
+            ((ErrorReporterImpl) errorReporterSingleton).unregister();
+            errorReporterSingleton = StubCreator.createErrorReporterStub();
         }
 
         //noinspection ConstantConditions
@@ -236,7 +238,6 @@ public final class ACRA {
     /**
      * @return true is ACRA has been initialised.
      */
-    @SuppressWarnings("unused")
     public static boolean isInitialised() {
         return errorReporterSingleton instanceof ErrorReporterImpl;
     }

--- a/acra-core/src/main/java/org/acra/builder/ReportExecutor.java
+++ b/acra-core/src/main/java/org/acra/builder/ReportExecutor.java
@@ -130,7 +130,7 @@ public class ReportExecutor {
                 if (!administrator.shouldStartCollecting(context, config, reportBuilder)) {
                     blockingAdministrator = administrator;
                 }
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 ACRA.log.w(LOG_TAG, "ReportingAdministrator " + administrator.getClass().getName() + " threw exception", t);
             }
         }
@@ -142,7 +142,7 @@ public class ReportExecutor {
                     if (!administrator.shouldSendReport(context, config, crashReportData)) {
                         blockingAdministrator = administrator;
                     }
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     ACRA.log.w(LOG_TAG, "ReportingAdministrator " + administrator.getClass().getName() + " threw exception", t);
                 }
             }
@@ -157,7 +157,7 @@ public class ReportExecutor {
                     if (!administrator.shouldFinishActivity(context, config, lastActivityManager)) {
                         finishActivity = false;
                     }
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     ACRA.log.w(LOG_TAG, "ReportingAdministrator " + administrator.getClass().getName() + " threw exception", t);
                 }
             }
@@ -185,7 +185,7 @@ public class ReportExecutor {
             if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Not sending crash report because of ReportingAdministrator " + blockingAdministrator.getClass().getName());
             try {
                 blockingAdministrator.notifyReportDropped(context, config);
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 ACRA.log.w(LOG_TAG, "ReportingAdministrator " + blockingAdministrator.getClass().getName() + " threw exeption", t);
             }
         }
@@ -198,7 +198,7 @@ public class ReportExecutor {
                     if (!administrator.shouldKillApplication(context, config, reportBuilder, crashReportData)) {
                         endApplication = false;
                     }
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     ACRA.log.w(LOG_TAG, "ReportingAdministrator " + administrator.getClass().getName() + " threw exception", t);
                 }
             }

--- a/acra-core/src/main/java/org/acra/collector/BaseReportFieldCollector.java
+++ b/acra-core/src/main/java/org/acra/collector/BaseReportFieldCollector.java
@@ -72,7 +72,7 @@ abstract class BaseReportFieldCollector implements Collector {
                 if (shouldCollect(context, config, field, reportBuilder)) {
                     collect(field, context, config, reportBuilder, target);
                 }
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 target.put(field, (String) null);
                 throw new CollectorException("Error while retrieving " + field.name() + " data:" + t.getMessage(), t);
             }

--- a/acra-core/src/main/java/org/acra/data/CrashReportDataFactory.java
+++ b/acra-core/src/main/java/org/acra/data/CrashReportDataFactory.java
@@ -57,12 +57,12 @@ public final class CrashReportDataFactory {
             Collector.Order o2;
             try {
                 o1 = c1.getOrder();
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 o1 = Collector.Order.NORMAL;
             }
             try {
                 o2 = c2.getOrder();
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 o2 = Collector.Order.NORMAL;
             }
             return o1.ordinal() - o2.ordinal();
@@ -89,7 +89,7 @@ public final class CrashReportDataFactory {
                     if(ACRA.DEV_LOGGING)ACRA.log.d(LOG_TAG, "Collector " + collector.getClass().getName() + " completed");
                 }catch (CollectorException e){
                     ACRA.log.w(LOG_TAG, e);
-                }catch (Throwable t) {
+                }catch (Exception t) {
                     ACRA.log.e(LOG_TAG, "Error in collector " + collector.getClass().getSimpleName(), t);
                 }
             }));
@@ -113,7 +113,7 @@ public final class CrashReportDataFactory {
                 //catch absolutely everything possible here so no collector obstructs the others
                 try {
                     ((ApplicationStartupCollector) collector).collectApplicationStartUp(context, config);
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     ACRA.log.w(ACRA.LOG_TAG, collector.getClass().getSimpleName() + " failed to collect its startup data", t);
                 }
             }

--- a/acra-core/src/main/java/org/acra/legacy/ReportConverter.java
+++ b/acra-core/src/main/java/org/acra/legacy/ReportConverter.java
@@ -78,12 +78,12 @@ class ReportConverter {
                     //reports without these keys are probably invalid
                     IOUtils.deleteFile(report);
                 }
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 try {
                     //If this succeeds the report has already been converted, happens e.g. on preference clear.
                     persister.load(report);
                     if (ACRA.DEV_LOGGING) ACRA.log.d(LOG_TAG, "Tried to convert already converted report file " + report.getPath() + ". Ignoring");
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     //File matches neither of the known formats, remove it.
                     ACRA.log.w(LOG_TAG, "Unable to read report file " + report.getPath() + ". Deleting", e);
                     IOUtils.deleteFile(report);

--- a/acra-core/src/main/java/org/acra/reporter/ErrorReporterImpl.java
+++ b/acra-core/src/main/java/org/acra/reporter/ErrorReporterImpl.java
@@ -59,6 +59,7 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
     private final ReportExecutor reportExecutor;
     private final Map<String, String> customData = new HashMap<>();
     private final SchedulerStarter schedulerStarter;
+    private final UncaughtExceptionHandler defaultExceptionHandler;
 
 
     /**
@@ -76,7 +77,6 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
         final CrashReportDataFactory crashReportDataFactory = new CrashReportDataFactory(context, config);
         crashReportDataFactory.collectStartUp();
 
-        final Thread.UncaughtExceptionHandler defaultExceptionHandler;
         defaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(this);
 
@@ -157,7 +157,7 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
                     .endApplication()
                     .build(reportExecutor);
 
-        } catch (Throwable fatality) {
+        } catch (Exception fatality) {
             // ACRA failed. Prevent any recursive call to ACRA.uncaughtException(), let the native reporter do its job.
             ACRA.log.e(LOG_TAG, "ACRA failed to capture the error - handing off to native error reporter", fatality);
             reportExecutor.handReportToDefaultExceptionHandler(t, e);
@@ -221,5 +221,9 @@ public class ErrorReporterImpl implements Thread.UncaughtExceptionHandler, Share
         if (ACRA.PREF_DISABLE_ACRA.equals(key) || ACRA.PREF_ENABLE_ACRA.equals(key)) {
             setEnabled(SharedPreferencesFactory.shouldEnableACRA(sharedPreferences));
         }
+    }
+
+    public void unregister() {
+        Thread.setDefaultUncaughtExceptionHandler(defaultExceptionHandler);
     }
 }

--- a/acra-core/src/main/java/org/acra/util/PackageManagerWrapper.java
+++ b/acra-core/src/main/java/org/acra/util/PackageManagerWrapper.java
@@ -62,7 +62,7 @@ public final class PackageManagerWrapper {
 
         try {
             return pm.checkPermission(permission, context.getPackageName()) == PackageManager.PERMISSION_GRANTED;
-        } catch (Throwable e) {
+        } catch (Exception e) {
             // To catch RuntimeException("Package manager has died") that can occur on some version of Android,
             // when the remote PackageManager is unavailable. I suspect this sometimes occurs when the App is being reinstalled.
             return false;
@@ -84,7 +84,7 @@ public final class PackageManagerWrapper {
         } catch (PackageManager.NameNotFoundException e) {
             ACRA.log.w(LOG_TAG, "Failed to find PackageInfo for current App : " + context.getPackageName());
             return null;
-        } catch (Throwable e) {
+        } catch (Exception e) {
             // To catch RuntimeException("Package manager has died") that can occur on some version of Android,
             // when the remote PackageManager is unavailable. I suspect this sometimes occurs when the App is being reinstalled.
             return null;

--- a/acra-core/src/test/java/org/acra/ACRATest.java
+++ b/acra-core/src/test/java/org/acra/ACRATest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.acra;
+
+import android.app.Application;
+import android.content.Context;
+import android.support.annotation.NonNull;
+import org.acra.builder.ReportBuilder;
+import org.acra.collector.StacktraceCollector;
+import org.acra.config.CoreConfiguration;
+import org.acra.config.CoreConfigurationBuilder;
+import org.acra.config.ReportingAdministrator;
+import org.acra.data.CrashReportData;
+import org.acra.plugins.SimplePluginLoader;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
+
+/**
+ * @author lukas
+ * @since 02.07.18
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ACRATest {
+
+    @Test
+    public void init() {
+        Application application = RuntimeEnvironment.application;
+        CoreConfigurationBuilder builder = new CoreConfigurationBuilder(application).setPluginLoader(new SimplePluginLoader(StacktraceCollector.class, TestAdministrator.class));
+        ACRA.init(application, builder);
+        ACRA.getErrorReporter().handleException(new RuntimeException());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void failing() {
+        Application application = RuntimeEnvironment.application;
+        CoreConfigurationBuilder builder = new CoreConfigurationBuilder(application).setPluginLoader(new SimplePluginLoader(FailingTestAdministrator.class));
+        ACRA.init(application, builder);
+        ACRA.getErrorReporter().handleException(new RuntimeException());
+    }
+
+    public static class TestAdministrator implements ReportingAdministrator {
+        @Override
+        public boolean shouldSendReport(@NonNull Context context, @NonNull CoreConfiguration config, @NonNull CrashReportData crashReportData) {
+            assertTrue(crashReportData.containsKey(ReportField.STACK_TRACE));
+            assertThat(crashReportData.getString(ReportField.STACK_TRACE), containsString("RuntimeException"));
+            return false;
+        }
+    }
+
+    public static class FailingTestAdministrator implements ReportingAdministrator {
+        @Override
+        public boolean shouldStartCollecting(@NonNull Context context, @NonNull CoreConfiguration config, @NonNull ReportBuilder reportBuilder) {
+            fail("Intended failure to test if assertions work");
+            return false;
+        }
+    }
+}

--- a/acra-notification/src/main/java/org/acra/receiver/NotificationBroadcastReceiver.java
+++ b/acra-notification/src/main/java/org/acra/receiver/NotificationBroadcastReceiver.java
@@ -85,7 +85,7 @@ public class NotificationBroadcastReceiver extends BroadcastReceiver {
                 }
             }
 
-        } catch (Throwable t) {
+        } catch (Exception t) {
             ACRA.log.e(LOG_TAG, "Failed to handle notification action", t);
         }
     }


### PR DESCRIPTION
- allow mulitple init calls
- do not catch errors (especially AssertionErrors)

@mikehardy you might be interested in the ACRATest class, as it serves as an example on how to test reports.