### PR TITLE
Fix "job without constraints" issue

### DIFF
--- a/acra-advanced-scheduler/src/main/java/org/acra/scheduler/RestartingAdministrator.java
+++ b/acra-advanced-scheduler/src/main/java/org/acra/scheduler/RestartingAdministrator.java
@@ -51,7 +51,7 @@ public class RestartingAdministrator extends HasConfigPlugin implements Reportin
                     assert scheduler != null;
                     PersistableBundle extras = new PersistableBundle();
                     extras.putString(RestartingAdministrator.EXTRA_LAST_ACTIVITY, lastActivityManager.getLastActivity().getClass().getName());
-                    scheduler.schedule(new JobInfo.Builder(0, new ComponentName(context, RestartingService.class)).setExtras(extras).build());
+                    scheduler.schedule(new JobInfo.Builder(0, new ComponentName(context, RestartingService.class)).setExtras(extras).setOverrideDeadline(100).build());
                 } catch (Exception e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Fixes #742, and forces the system to execute the job (and therefore, to restart the app) "immediately"