### PR TITLE
Alter proguard rule - Plugin is interface not class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,23 @@
 language: android
+env:
+  global:
+    # PATH order is incredibly important. e.g. the 'emulator' script exists in more than one place!
+    - ANDROID_HOME=/usr/local/android-sdk
+    - TOOLS=${ANDROID_HOME}/tools
+    - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
 android:
   components:
-    - build-tools-28.0.2
-    - android-28
+    # installing tools to start, then use `sdkmanager` below to get the rest
+    - tools
+licenses:
+    - 'android-sdk-preview-license-.+'
+    - 'android-sdk-license-.+'
+install:
+  - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid harmless sdkmanager warning
+  - echo y | sdkmanager "platform-tools" >/dev/null
+  - echo y | sdkmanager "tools" >/dev/null # A second time per Travis docs, gets latest versions
+  - echo y | sdkmanager "build-tools;28.0.2" >/dev/null # Implicit gradle dependency - gradle drives changes
+  - echo y | sdkmanager "platforms;android-28" >/dev/null # We need the API of the emulator we will run
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/acra-core/proguard.cfg
+++ b/acra-core/proguard.cfg
@@ -10,7 +10,7 @@
 -keepattributes *Annotation*
 
 # ACRA loads Plugins using reflection, so we need to keep all Plugin classes
--keep class * extends org.acra.plugins.Plugin {*;}
+-keep class * implements org.acra.plugins.Plugin {*;}
 
 # ACRA uses enum fields in annotations, so we have to keep those
 -keep enum org.acra.** {*;}


### PR DESCRIPTION
This responds to a warning I saw with the D8 code shrinker:

```
D8: The rule `-keep class * extends org.acra.plugins.Plugin {
  *;
}` uses extends but actually matches implements.
```

apologies for the trailing white space - I used the github web interface to do this one and the textarea just does it's thing. Feel free to nuke this PR and do it cleanly yourself if you like, it's trivial