### PR TITLE
Migrate from RuntimeEnvironment to ApplicationProvider

### DIFF
--- a/acra-core/src/test/java/org/acra/ACRATest.java
+++ b/acra-core/src/test/java/org/acra/ACRATest.java
@@ -18,6 +18,7 @@ package org.acra;
 
 import android.app.Application;
 import android.content.Context;
+import android.os.Build;
 import android.support.annotation.NonNull;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -32,6 +33,7 @@ import org.acra.plugins.SimplePluginLoader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
@@ -40,6 +42,7 @@ import static org.junit.Assert.*;
  * @author lukas
  * @since 02.07.18
  */
+@Config(sdk = Build.VERSION_CODES.P)
 @RunWith(RobolectricTestRunner.class)
 public class ACRATest {
 

--- a/acra-core/src/test/java/org/acra/ACRATest.java
+++ b/acra-core/src/test/java/org/acra/ACRATest.java
@@ -19,6 +19,9 @@ package org.acra;
 import android.app.Application;
 import android.content.Context;
 import android.support.annotation.NonNull;
+
+import androidx.test.core.app.ApplicationProvider;
+
 import org.acra.builder.ReportBuilder;
 import org.acra.collector.StacktraceCollector;
 import org.acra.config.CoreConfiguration;
@@ -29,7 +32,6 @@ import org.acra.plugins.SimplePluginLoader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
@@ -43,7 +45,7 @@ public class ACRATest {
 
     @Test
     public void init() {
-        Application application = RuntimeEnvironment.application;
+        Application application = ApplicationProvider.getApplicationContext();
         CoreConfigurationBuilder builder = new CoreConfigurationBuilder(application).setPluginLoader(new SimplePluginLoader(StacktraceCollector.class, TestAdministrator.class));
         ACRA.init(application, builder);
         ACRA.getErrorReporter().handleException(new RuntimeException());
@@ -51,7 +53,7 @@ public class ACRATest {
 
     @Test(expected = AssertionError.class)
     public void failing() {
-        Application application = RuntimeEnvironment.application;
+        Application application = ApplicationProvider.getApplicationContext();
         CoreConfigurationBuilder builder = new CoreConfigurationBuilder(application).setPluginLoader(new SimplePluginLoader(FailingTestAdministrator.class));
         ACRA.init(application, builder);
         ACRA.getErrorReporter().handleException(new RuntimeException());

--- a/acra-core/src/test/java/org/acra/attachment/AcraContentProviderTest.java
+++ b/acra-core/src/test/java/org/acra/attachment/AcraContentProviderTest.java
@@ -19,6 +19,7 @@ package org.acra.attachment;
 import android.content.ContentResolver;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.OpenableColumns;
 import android.webkit.MimeTypeMap;
 
@@ -34,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
 
 import java.io.File;
 
@@ -46,6 +48,7 @@ import static junit.framework.Assert.assertTrue;
  * @author F43nd1r
  * @since 04.12.2017
  */
+@Config(sdk = Build.VERSION_CODES.P)
 @RunWith(RobolectricTestRunner.class)
 public class AcraContentProviderTest {
     private static final String JSON_EXTENSION = "json";

--- a/acra-core/src/test/java/org/acra/attachment/AcraContentProviderTest.java
+++ b/acra-core/src/test/java/org/acra/attachment/AcraContentProviderTest.java
@@ -22,6 +22,8 @@ import android.net.Uri;
 import android.provider.OpenableColumns;
 import android.webkit.MimeTypeMap;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.google.common.net.MediaType;
 
 import org.acra.ACRA;
@@ -31,7 +33,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 
 import java.io.File;
@@ -57,15 +58,15 @@ public class AcraContentProviderTest {
     public void setUp() throws Exception {
         ACRA.log = new RobolectricLog();
         ACRA.DEV_LOGGING = true;
-        Robolectric.setupContentProvider(AcraContentProvider.class, RuntimeEnvironment.application.getPackageName() + ".acra");
-        resolver = RuntimeEnvironment.application.getContentResolver();
+        Robolectric.setupContentProvider(AcraContentProvider.class, ApplicationProvider.getApplicationContext().getPackageName() + ".acra");
+        resolver = ApplicationProvider.getApplicationContext().getContentResolver();
         file = File.createTempFile("test", "." + JSON_EXTENSION);
         Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping(JSON_EXTENSION, JSON_MIMETYPE);
     }
 
     @Test
     public void query() {
-        final Cursor cursor = resolver.query(AcraContentProvider.getUriForFile(RuntimeEnvironment.application, file), new String[]{OpenableColumns.SIZE, OpenableColumns.DISPLAY_NAME}, null, null, null);
+        final Cursor cursor = resolver.query(AcraContentProvider.getUriForFile(ApplicationProvider.getApplicationContext(), file), new String[]{OpenableColumns.SIZE, OpenableColumns.DISPLAY_NAME}, null, null, null);
         assertNotNull(cursor);
         assertTrue(cursor.moveToFirst());
         assertEquals(file.length(), cursor.getInt(0));
@@ -76,14 +77,14 @@ public class AcraContentProviderTest {
 
     @Test
     public void openFile() throws Exception {
-        final Uri uri = AcraContentProvider.getUriForFile(RuntimeEnvironment.application, file);
+        final Uri uri = AcraContentProvider.getUriForFile(ApplicationProvider.getApplicationContext(), file);
         assertNotNull(resolver.openFileDescriptor(uri, "r"));
 
     }
 
     @Test
     public void guessMimeType() {
-        assertEquals(JSON_MIMETYPE, AcraContentProvider.guessMimeType(AcraContentProvider.getUriForFile(RuntimeEnvironment.application, file)));
+        assertEquals(JSON_MIMETYPE, AcraContentProvider.guessMimeType(AcraContentProvider.getUriForFile(ApplicationProvider.getApplicationContext(), file)));
     }
 
 }

--- a/acra-core/src/test/java/org/acra/attachment/DefaultAttachmentProviderTest.java
+++ b/acra-core/src/test/java/org/acra/attachment/DefaultAttachmentProviderTest.java
@@ -19,11 +19,12 @@ package org.acra.attachment;
 import android.app.Application;
 import android.net.Uri;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import org.acra.config.CoreConfigurationBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class DefaultAttachmentProviderTest {
     @Test
     public void getAttachments() throws Exception {
         Uri uri = Uri.parse("content://not-a-valid-content-uri");
-        List<Uri> result = new DefaultAttachmentProvider().getAttachments(RuntimeEnvironment.application, new CoreConfigurationBuilder(new Application()).setAttachmentUris(uri.toString()).build());
+        List<Uri> result = new DefaultAttachmentProvider().getAttachments(ApplicationProvider.getApplicationContext(), new CoreConfigurationBuilder(new Application()).setAttachmentUris(uri.toString()).build());
         assertThat(result, hasSize(1));
         assertEquals(uri, result.get(0));
     }

--- a/acra-core/src/test/java/org/acra/attachment/DefaultAttachmentProviderTest.java
+++ b/acra-core/src/test/java/org/acra/attachment/DefaultAttachmentProviderTest.java
@@ -18,6 +18,7 @@ package org.acra.attachment;
 
 import android.app.Application;
 import android.net.Uri;
+import android.os.Build;
 
 import androidx.test.core.app.ApplicationProvider;
 
@@ -25,6 +26,7 @@ import org.acra.config.CoreConfigurationBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.List;
 
@@ -36,6 +38,7 @@ import static org.hamcrest.Matchers.hasSize;
  * @author F43nd1r
  * @since 30.11.2017
  */
+@Config(sdk = Build.VERSION_CODES.P)
 @RunWith(RobolectricTestRunner.class)
 public class DefaultAttachmentProviderTest {
     @Test

--- a/acra-core/src/test/java/org/acra/config/CoreConfigurationBuilderTest.java
+++ b/acra-core/src/test/java/org/acra/config/CoreConfigurationBuilderTest.java
@@ -1,11 +1,13 @@
 package org.acra.config;
 
 import android.app.Application;
+import android.os.Build;
 
 import org.acra.annotation.AcraCore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -14,6 +16,7 @@ import static org.junit.Assert.assertTrue;
  * @author F43nd1r
  * @since 01.02.18
  */
+@Config(sdk = Build.VERSION_CODES.P)
 @RunWith(RobolectricTestRunner.class)
 public class CoreConfigurationBuilderTest {
 

--- a/acra-core/src/test/java/org/acra/data/CrashReportDataTest.java
+++ b/acra-core/src/test/java/org/acra/data/CrashReportDataTest.java
@@ -16,10 +16,13 @@
 
 package org.acra.data;
 
+import android.os.Build;
+
 import org.acra.ReportField;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.Map;
 
@@ -30,6 +33,7 @@ import static junit.framework.Assert.assertTrue;
  * @author F43nd1r
  * @since 29.11.2017
  */
+@Config(sdk = Build.VERSION_CODES.P)
 @RunWith(RobolectricTestRunner.class)
 public class CrashReportDataTest {
     @Test

--- a/acra-core/src/test/java/org/acra/data/StringFormatTest.java
+++ b/acra-core/src/test/java/org/acra/data/StringFormatTest.java
@@ -17,6 +17,8 @@
 package org.acra.data;
 
 
+import android.os.Build;
+
 import com.google.common.net.MediaType;
 
 import org.acra.ReportField;
@@ -26,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
 
@@ -33,6 +36,7 @@ import static junit.framework.Assert.assertEquals;
  * @author F43nd1r
  * @since 29.11.2017
  */
+@Config(sdk = Build.VERSION_CODES.P)
 @RunWith(RobolectricTestRunner.class)
 public class StringFormatTest {
     private CrashReportData reportData;

--- a/acra-core/src/test/java/org/acra/util/InstallationTest.java
+++ b/acra-core/src/test/java/org/acra/util/InstallationTest.java
@@ -16,11 +16,14 @@
 
 package org.acra.util;
 
+import android.os.Build;
+
 import androidx.test.core.app.ApplicationProvider;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.io.File;
 
@@ -32,6 +35,7 @@ import static org.junit.Assert.assertThat;
  * @author F43nd1r
  * @since 29.11.2017
  */
+@Config(sdk = Build.VERSION_CODES.P)
 @RunWith(RobolectricTestRunner.class)
 public class InstallationTest {
     @Test

--- a/acra-core/src/test/java/org/acra/util/InstallationTest.java
+++ b/acra-core/src/test/java/org/acra/util/InstallationTest.java
@@ -16,10 +16,11 @@
 
 package org.acra.util;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.File;
 
@@ -35,12 +36,12 @@ import static org.junit.Assert.assertThat;
 public class InstallationTest {
     @Test
     public void id() {
-        final String id = Installation.id(RuntimeEnvironment.application);
-        assertEquals(id, Installation.id(RuntimeEnvironment.application));
-        for(File child : RuntimeEnvironment.application.getFilesDir().listFiles()){
+        final String id = Installation.id(ApplicationProvider.getApplicationContext());
+        assertEquals(id, Installation.id(ApplicationProvider.getApplicationContext()));
+        for(File child : ApplicationProvider.getApplicationContext().getFilesDir().listFiles()){
             if(child.isFile()) child.delete();
         }
-        assertThat(Installation.id(RuntimeEnvironment.application), not(id));
+        assertThat(Installation.id(ApplicationProvider.getApplicationContext()), not(id));
     }
 
 }

--- a/acra-core/src/test/java/org/acra/util/InstanceCreatorTest.java
+++ b/acra-core/src/test/java/org/acra/util/InstanceCreatorTest.java
@@ -1,15 +1,19 @@
 package org.acra.util;
 
+import android.os.Build;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
+@Config(sdk = Build.VERSION_CODES.P)
 @RunWith(RobolectricTestRunner.class)
 public class InstanceCreatorTest {
     private InstanceCreator instanceCreator;


### PR DESCRIPTION
RuntimeEnvironment.application provided by Robolectric, used in the test code, has been deprecated.
So I replaced it with ApplicationProvider.getApplicationContext() provided by androidx.
This is also recommended by [Robolectric](https://github.com/robolectric/robolectric/blob/cbc06b111d2af9616822893fc91dc131685e4c4d/shadows/framework/src/main/java/org/robolectric/RuntimeEnvironment.java#L26).