### PR TITLE
fix(core, reporter): default exception handler may be null

### DIFF
--- a/acra-core/src/main/java/org/acra/reporter/ErrorReporterImpl.kt
+++ b/acra-core/src/main/java/org/acra/reporter/ErrorReporterImpl.kt
@@ -61,7 +61,7 @@ class ErrorReporterImpl(private val context: Application, config: CoreConfigurat
     private val reportExecutor: ReportExecutor
     private val customData: MutableMap<String, String> = HashMap()
     private val schedulerStarter: SchedulerStarter
-    private val defaultExceptionHandler: Thread.UncaughtExceptionHandler
+    private val defaultExceptionHandler: Thread.UncaughtExceptionHandler?
 
     override fun putCustomData(key: String, value: String): String? {
         return customData.put(key, value)
@@ -159,7 +159,7 @@ class ErrorReporterImpl(private val context: Application, config: CoreConfigurat
     init {
         val crashReportDataFactory = CrashReportDataFactory(context, config)
         crashReportDataFactory.collectStartUp()
-        defaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()!!
+        defaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler(this)
         val lastActivityManager = LastActivityManager(context)
         val processFinisher = ProcessFinisher(context, config, lastActivityManager)


### PR DESCRIPTION
Underlying Java API documents it as potentially null
https://developer.android.com/reference/java/lang/Thread#getDefaultUncaughtExceptionHandler()

Null values are handled in ReportExecutor (the only consumer of this value that I know of?):
https://github.com/ACRA/acra/blob/042eddd1a649af3066ca5bf5c4573040533bcd32/acra-core/src/main/java/org/acra/builder/ReportExecutor.kt#L51

Fixes a crash in robolectric contexts where it actually is null

Test Plan: I made the correct package directory structure, copied the original version of the file in to AnkiDroid's codebase that way and ran it - reproduce the failure in our robolectric tests - ran this changed version and it worked

Also `./gradlew test` passed locally