### PR TITLE
Send most recent unnaproved report to avoid continuous interactions on App startup

### DIFF
--- a/acra-core/src/main/java/org/acra/startup/StartupProcessorExecutor.kt
+++ b/acra-core/src/main/java/org/acra/startup/StartupProcessorExecutor.kt
@@ -49,8 +49,9 @@ class StartupProcessorExecutor(private val context: Context, private val config:
                             report.delete -> if (!report.file.delete()) warn { "Could not delete report ${report.file}" }
                             report.approved -> send = true
                             report.approve && isAcraEnabled -> {
-                                    ReportInteractionExecutor(context, config).performInteractions(report.file)
-                                    schedulerStarter.scheduleReports(report.file, false)
+                                    if (ReportInteractionExecutor(context, config).performInteractions(report.file)){
+                                        schedulerStarter.scheduleReports(report.file, false)
+                                    }
                                 }
                             }
                         }

--- a/acra-core/src/main/java/org/acra/startup/StartupProcessorExecutor.kt
+++ b/acra-core/src/main/java/org/acra/startup/StartupProcessorExecutor.kt
@@ -48,7 +48,11 @@ class StartupProcessorExecutor(private val context: Context, private val config:
                         when {
                             report.delete -> if (!report.file.delete()) warn { "Could not delete report ${report.file}" }
                             report.approved -> send = true
-                            report.approve && isAcraEnabled -> ReportInteractionExecutor(context, config).performInteractions(report.file)
+                            report.approve && isAcraEnabled -> {
+                                    ReportInteractionExecutor(context, config).performInteractions(report.file)
+                                    schedulerStarter.scheduleReports(report.file, false)
+                                }
+                            }
                         }
                     }
                 }

--- a/acra-core/src/main/java/org/acra/startup/StartupProcessorExecutor.kt
+++ b/acra-core/src/main/java/org/acra/startup/StartupProcessorExecutor.kt
@@ -49,9 +49,8 @@ class StartupProcessorExecutor(private val context: Context, private val config:
                             report.delete -> if (!report.file.delete()) warn { "Could not delete report ${report.file}" }
                             report.approved -> send = true
                             report.approve && isAcraEnabled -> {
-                                    if (ReportInteractionExecutor(context, config).performInteractions(report.file)){
-                                        schedulerStarter.scheduleReports(report.file, false)
-                                    }
+                                if (ReportInteractionExecutor(context, config).performInteractions(report.file)) {
+                                    schedulerStarter.scheduleReports(report.file, false)
                                 }
                             }
                         }


### PR DESCRIPTION
I have been tracking down the reason why my app is constantly showing Toast interaction on App startup. From what I could understand, my app got to an state where there is a single unnaproved report instance. This report is processed by UnnaprovedStartupProcessor, and its "approve" property is set to true.

https://github.com/ACRA/acra/blob/f99e61da72ebfce78b5f80a6c6cc8f4672555670/acra-core/src/main/java/org/acra/startup/UnapprovedStartupProcessor.kt#L42

Since only its "approve" property is set to true, variable "send" remains as false during execution of StartupProcessorExecutor.processReports method. 

https://github.com/ACRA/acra/blob/f99e61da72ebfce78b5f80a6c6cc8f4672555670/acra-core/src/main/java/org/acra/startup/StartupProcessorExecutor.kt#L42-L57

The ReportInteractionExecutor.performInteractions method is called, displaying the Toast with error message, but the report is never sent. This behavior may lead users to confusion, since a report is expected on my server to inspect the cause. Also, this most recent unnaproved report is never moved approved report folder, then the Toast message is always displayed on App startup.

This pull request is my suggestion to change this behavior. My idea is to call schedulerStarter.scheduleReports, so the report is sent when message is shown. Also, this report will be moved to the approved report folder, and it will be handled differently on next startup. Please, let me know if this make sense to you.

Hope it contribute somehow to this amazing library.