### PR TITLE
bug fix: no email app selector was shown on Android 13

### DIFF
--- a/acra-mail/src/main/java/org/acra/sender/EmailIntentSender.kt
+++ b/acra-mail/src/main/java/org/acra/sender/EmailIntentSender.kt
@@ -188,7 +188,8 @@ class EmailIntentSender(private val config: CoreConfiguration) : ReportSender {
      * @return email intent
      */
     protected fun buildSingleAttachmentIntent(subject: String, body: String?, attachment: Uri): Intent {
-        val intent = Intent(Intent.ACTION_SEND)
+        val intent = Intent(Intent.ACTION_SENDTO)
+        intent.data = Uri.parse("mailto:")
         intent.putExtra(Intent.EXTRA_EMAIL, arrayOf(mailConfig.mailTo))
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         intent.putExtra(Intent.EXTRA_SUBJECT, subject)


### PR DESCRIPTION
On Android 13, the selector for sending emails is not showing up anymore. Apparently, the recently introduced fix in version 5.9.7 doesn't help. I fixed it at least for sending emails with single attachments. But I don't know if it still works on older Android versions and if multiple attachments are used. 