### PR TITLE
fix: use 0 as last chance lastVersion fallback for limiter

### DIFF
--- a/acra-limiter/src/main/java/org/acra/startup/LimiterStartupProcessor.kt
+++ b/acra-limiter/src/main/java/org/acra/startup/LimiterStartupProcessor.kt
@@ -43,6 +43,8 @@ class LimiterStartupProcessor : HasConfigPlugin(LimiterConfiguration::class.java
                 prefs.getLong(ACRA.PREF_LAST_VERSION_NR, 0)
             } catch (e: ClassCastException) {
                 prefs.getInt(ACRA.PREF_LAST_VERSION_NR, 0).toLong()
+            } catch (e: Exception) {
+                0
             }
             val appVersion = getAppVersion(context)
             if (appVersion > lastVersionNr) {


### PR DESCRIPTION

This is a speculative fix for #1233 https://github.com/ankidroid/Anki-Android/issues/14348

I'm not sure if 1) this is valid kotlin (I just tapped it out in the github web UI or 2) if I'm understanding the problem correctly

It is confusing to me how this (exception apparently from the original catch block...) could happen. I don't understand that and may be missing something simple

But *if* we end up in that catch block and then for whatever reason cannot go from Long to Integer, then at the very least we can avoid crashing an app on startup by simply using zero (or backup value in any case...) as a final "well, at least we tried..." value

I have no pride in the code or thought behind the solution, if it's terrible, close and we can all forget about it ;-). Would love to see #1233 fixed though