### PR TITLE
fix(docs): fix notification channel importance usage

### DIFF
--- a/web/docs/Interactions.mdx
+++ b/web/docs/Interactions.mdx
@@ -145,7 +145,7 @@ notification {
     //optional channel description
     channelDescription = getString(R.string.notification_channel_desc)
     //defaults to NotificationManager.IMPORTANCE_HIGH
-    resChannelImportance = NotificationManager.IMPORTANCE_MAX
+    channelImportance = NotificationManager.IMPORTANCE_MAX
     //optional, enables ticker text
     tickerText = getString(R.string.notification_ticker)
     //defaults to android.R.drawable.stat_sys_warning
@@ -180,7 +180,7 @@ new NotificationConfigurationBuilder()
     //optional channel description
     .withChannelDescription(getString(R.string.notification_channel_desc))
     //defaults to NotificationManager.IMPORTANCE_HIGH
-    .withResChannelImportance(NotificationManager.IMPORTANCE_MAX)
+    .withChannelImportance(NotificationManager.IMPORTANCE_MAX)
     //optional, enables ticker text
     .withTickerText(getString(R.string.notification_ticker))
     //defaults to android.R.drawable.stat_sys_warning


### PR DESCRIPTION
When I tried copying the [notification interaction](https://www.acra.ch/docs/Interactions#notification) into my project, the `resChannelImportance` of the `NotificationConfigurationBuilder` could not be found.

It seems to be called `channelImportance` now?

[This](https://github.com/ACRA/acra/blob/0c2b36ceb873f75b7528cd76f2fefec3f0d5ac23/acra-notification/src/main/java/org/acra/config/NotificationConfiguration.kt#L136) should be the corresponding source code.