### PR TITLE
Fix typo : add "class" keyword

### DIFF
--- a/web/docs/Custom-Extensions.mdx
+++ b/web/docs/Custom-Extensions.mdx
@@ -15,7 +15,7 @@ Example:
 <AndroidCode>
 
 ```kotlin
-MyAdmin : ReportingAdministrator {
+class MyAdmin : ReportingAdministrator {
     init {
         Log.d("MyAdmin", "MyAdmin was loaded")
     }


### PR DESCRIPTION
In [Custom Extensions](https://www.acra.ch/docs/Custom-Extensions) page