### PR TITLE
Add a note about `ReportSenderException` 

### DIFF
--- a/web/docs/Senders.mdx
+++ b/web/docs/Senders.mdx
@@ -142,7 +142,7 @@ Emails are sent with an `ACTION_SEND_MULTIPLE` intent. This means that the follo
 
 ## Implementing your own sender
 
-You can implement your own `ReportSender` and configure ACRA to use that instead of or in addition to other senders.
+You can implement your own `ReportSender` and configure ACRA to use that instead of or in addition to other senders. If `YourCustomSender.send()` throws a `ReportSenderException`, ACRA will retry to send the report later.
 
 <AndroidCode>
 

--- a/web/docs/Senders.mdx
+++ b/web/docs/Senders.mdx
@@ -142,7 +142,10 @@ Emails are sent with an `ACTION_SEND_MULTIPLE` intent. This means that the follo
 
 ## Implementing your own sender
 
-You can implement your own `ReportSender` and configure ACRA to use that instead of or in addition to other senders. If `YourCustomSender.send()` throws a `ReportSenderException`, ACRA will retry to send the report later.
+You can implement your own `ReportSender` and configure ACRA to use that instead of or in addition to other senders.
+
+:::Tip
+Throwing a `ReportSenderException` from `YourCustomSender.send()` notifies ACRA of a failed delivery, and might trigger a retry (see [RetryPolicy](https://www.acra.ch/javadoc/latest/acra/org.acra.config/-core-configuration/retry-policy-class.html)).
 
 <AndroidCode>
 


### PR DESCRIPTION
[acra-http throws a ReportSenderException if it fails to send the report](https://github.com/ACRA/acra/blob/master/acra-http/src/main/java/org/acra/sender/HttpSender.kt#L118), so I imagine it's a mechanism to allow for a later retry. ACRA's message is pretty clear: `org.acra.sender.ReportSenderException: Policy marked this task as incomplete. ACRA will try to send this report again`.

I thought it would be nice to document it. It might need to be rephrased.