### PR TITLE
fix: forward-port to R8 next major version

### DIFF
--- a/acra-core/proguard.cfg
+++ b/acra-core/proguard.cfg
@@ -12,7 +12,7 @@
 -keepclassmembers class * implements org.acra.config.Configuration { <init>(...); }
 
 # ACRA creates a proxy for this interface
--keep interface org.acra.ErrorReporter
+-keep interface org.acra.ErrorReporter { void <init>(); }
 
 -dontwarn android.support.**
 


### PR DESCRIPTION
This is in response to this warning and is simply the suggested change, with the intention that it is non-functional / results in the same keep behavior as before

> WARNING: /Users/mike/.gradle/caches/8.10.2/transforms/05e2bc486ed1e2d3388799eab04515e2/transformed/acra-core-5.11.4/proguard.txt:15:1-17:1: R8: The current version of R8 implicitly keeps the default constructor for Proguard configuration rules that have no member pattern. If the following rule should continue to keep the default constructor in the next major version of R8, then it must be augmented with the member pattern `{ void <init>(); }` to explicitly keep the default constructor: -keep interface org.acra.ErrorReporter