### PR TITLE
Put only `auto-service-annotations` in classpath, not `auto-service`.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-junit" }
 hamcrest = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
 autoService-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "autoServiceKsp" }
-autoService-annotations = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
+autoService-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 autoDsl-processor = {module = "com.faendir.kotlin.autodsl:processor", version.ref = "autoDsl"}
 autoDsl-annotations = {module = "com.faendir.kotlin.autodsl:annotations", version.ref = "autoDsl"}
 


### PR DESCRIPTION
Compare https://github.com/ACRA/acra/issues/738, which discussed a
change in documentation for _users'_ builds. This PR changes how ACRA
itself depends on AutoService.

This keeps the Auto-Service annotation processor, as well as
dependencies like Auto-Common and Guava, out of the runtime classpath.

By keeping Guava in particular out of the runtime classpath, we reduce
the chances that users encounter problems with Guava's strange
dependency structure, as discussed in
https://issuetracker.google.com/issues/457186394#comment5.
